### PR TITLE
Correct m200 mean halo masses

### DIFF
--- a/src/gadgetio.cxx
+++ b/src/gadgetio.cxx
@@ -172,20 +172,20 @@ void ReadGadget(Options &opt, vector<Particle> &Part, const Int_t nbodies,Partic
         opt.Omega_Lambda=header[ifirstfile].OmegaLambda;
         opt.h=header[ifirstfile].HubbleParam;
         opt.Omega_cdm=opt.Omega_m-opt.Omega_b;
+        CalcOmegak(opt);
         //Hubble flow
         if (opt.comove) aadjust=1.0;
         else aadjust=opt.a;
-        Hubble=opt.h*opt.H*sqrt((1-opt.Omega_m-opt.Omega_Lambda)*pow(aadjust,-2.0)+opt.Omega_m*pow(aadjust,-3.0)+opt.Omega_Lambda);
-        opt.rhobg=3.*Hubble*Hubble/(8.0*M_PI*opt.G)*opt.Omega_m;
-        Double_t bnx=-((1-opt.Omega_m-opt.Omega_Lambda)*pow(aadjust,-2.0)+opt.Omega_Lambda)/((1-opt.Omega_m-opt.Omega_Lambda)*pow(aadjust,-2.0)+opt.Omega_m*pow(aadjust,-3.0)+opt.Omega_Lambda);
-        opt.virBN98=(18.0*M_PI*M_PI+82.0*bnx-39*bnx*bnx)/opt.Omega_m;
+        Hubble=GetHubble(opt, aadjust);
+        CalcCriticalDensity(opt, aadjust);
+        CalcVirBN98(opt,aadjust);
         //if opt.virlevel<0, then use virial overdensity based on Bryan and Norman 1997 virialization level is given by
         if (opt.virlevel<0) opt.virlevel=opt.virBN98;
 
         //normally Hubbleflow=lvscale*Hubble but we only care about peculiar velocities
         //ignore hubble flow
         Hubbleflow=0.;
-        cout<<"Cosmology (h,Omega_m,Omega_cdm,Omega_b,Omega_L) = ("<< opt.h<<","<<opt.Omega_m<<","<<opt.Omega_cdm<<","<<opt.Omega_b<<","<<opt.Omega_Lambda<<")"<<endl;
+        PrintCosmology(opt);
     }
     //otherwise, really don't have the same meaning and values are based on input configuration values
     else {

--- a/src/gadgetio.cxx
+++ b/src/gadgetio.cxx
@@ -178,6 +178,7 @@ void ReadGadget(Options &opt, vector<Particle> &Part, const Int_t nbodies,Partic
         else aadjust=opt.a;
         Hubble=GetHubble(opt, aadjust);
         CalcCriticalDensity(opt, aadjust);
+        CalcBackgroundDensity(opt, aadjust);
         CalcVirBN98(opt,aadjust);
         //if opt.virlevel<0, then use virial overdensity based on Bryan and Norman 1997 virialization level is given by
         if (opt.virlevel<0) opt.virlevel=opt.virBN98;

--- a/src/hdfio.cxx
+++ b/src/hdfio.cxx
@@ -512,6 +512,7 @@ void ReadHDF(Options &opt, vector<Particle> &Part, const Int_t nbodies,Particle 
         else aadjust=opt.a;
         Hubble=GetHubble(opt, aadjust);
         CalcCriticalDensity(opt, aadjust);
+        CalcBackgroundDensity(opt, aadjust);
         CalcVirBN98(opt,aadjust);
         //if opt.virlevel<0, then use virial overdensity based on Bryan and Norman 1997 virialization level is given by
         if (opt.virlevel<0) opt.virlevel=opt.virBN98;

--- a/src/hdfio.cxx
+++ b/src/hdfio.cxx
@@ -506,16 +506,16 @@ void ReadHDF(Options &opt, vector<Particle> &Part, const Int_t nbodies,Particle 
         opt.Omega_Lambda=hdf_header_info[ifirstfile].OmegaLambda;
         opt.h=hdf_header_info[ifirstfile].HubbleParam;
         opt.Omega_cdm=opt.Omega_m-opt.Omega_b;
+        CalcOmegak(opt);
         //Hubble flow
         if (opt.comove) aadjust=1.0;
         else aadjust=opt.a;
-        Hubble=opt.h*opt.H*sqrt((1-opt.Omega_m-opt.Omega_Lambda)*pow(aadjust,-2.0)+opt.Omega_m*pow(aadjust,-3.0)+opt.Omega_Lambda);
-        opt.rhobg=3.*Hubble*Hubble/(8.0*M_PI*opt.G)*opt.Omega_m;
-        Double_t bnx=-((1-opt.Omega_m-opt.Omega_Lambda)*pow(aadjust,-2.0)+opt.Omega_Lambda)/((1-opt.Omega_m-opt.Omega_Lambda)*pow(aadjust,-2.0)+opt.Omega_m*pow(aadjust,-3.0)+opt.Omega_Lambda);
-        opt.virBN98=(18.0*M_PI*M_PI+82.0*bnx-39*bnx*bnx)/opt.Omega_m;
+        Hubble=GetHubble(opt, aadjust);
+        CalcCriticalDensity(opt, aadjust);
+        CalcVirBN98(opt,aadjust);
         //if opt.virlevel<0, then use virial overdensity based on Bryan and Norman 1997 virialization level is given by
         if (opt.virlevel<0) opt.virlevel=opt.virBN98;
-        cout<<"Cosmology (h,Omega_m,Omega_cdm,Omega_b,Omega_L) = ("<< opt.h<<","<<opt.Omega_m<<","<<opt.Omega_cdm<<","<<opt.Omega_b<<","<<opt.Omega_Lambda<<")"<<endl;
+        PrintCosmology(opt);
     }
     else {
       opt.a=1.0;

--- a/src/ramsesio.cxx
+++ b/src/ramsesio.cxx
@@ -594,6 +594,7 @@ void ReadRamses(Options &opt, vector<Particle> &Part, const Int_t nbodies, Parti
     CalcOmegak(opt);
     Hubble=GetHubble(opt, aadjust);
     CalcCriticalDensity(opt, aadjust);
+    CalcBackgroundDensity(opt, aadjust);
     CalcVirBN98(opt,aadjust);
     //if opt.virlevel<0, then use virial overdensity based on Bryan and Norman 1997 virialization level is given by
     if (opt.virlevel<0) opt.virlevel=opt.virBN98;

--- a/src/ramsesio.cxx
+++ b/src/ramsesio.cxx
@@ -591,12 +591,13 @@ void ReadRamses(Options &opt, vector<Particle> &Part, const Int_t nbodies, Parti
     //Hubble flow
     if (opt.comove) aadjust=1.0;
     else aadjust=opt.a;
-    Hubble=opt.h*opt.H*sqrt((1-opt.Omega_m-opt.Omega_Lambda)*pow(aadjust,-2.0)+opt.Omega_m*pow(aadjust,-3.0)+opt.Omega_Lambda);
-    opt.rhobg=3.*Hubble*Hubble/(8.0*M_PI*opt.G)*opt.Omega_m;
-    Double_t bnx=-((1-opt.Omega_m-opt.Omega_Lambda)*pow(aadjust,-2.0)+opt.Omega_Lambda)/((1-opt.Omega_m-opt.Omega_Lambda)*pow(aadjust,-2.0)+opt.Omega_m*pow(aadjust,-3.0)+opt.Omega_Lambda);
-    opt.virBN98=(18.0*M_PI*M_PI+82.0*bnx-39*bnx*bnx)/opt.Omega_m;
+    CalcOmegak(opt);
+    Hubble=GetHubble(opt, aadjust);
+    CalcCriticalDensity(opt, aadjust);
+    CalcVirBN98(opt,aadjust);
     //if opt.virlevel<0, then use virial overdensity based on Bryan and Norman 1997 virialization level is given by
     if (opt.virlevel<0) opt.virlevel=opt.virBN98;
+    PrintCosmology(opt);
 
     //adjust length scale so that convert from 0 to 1 (box units) to kpc comoving
     //to scale mpi domains correctly need to store in opt.L the box size in comoving little h value
@@ -622,7 +623,6 @@ void ReadRamses(Options &opt, vector<Particle> &Part, const Int_t nbodies, Parti
 
     //for (int j=0;j<NPARTTYPES;j++) nbodies+=opt.numpart[j];
     cout<<"Particle system contains "<<nbodies<<" particles (of interest) at is at time "<<opt.a<<" in a box of size "<<opt.p<<endl;
-    cout<<"Cosmology (h,Omega_m,Omega_cdm,Omega_b,Omega_L) = ("<< opt.h<<","<<opt.Omega_m<<","<<opt.Omega_cdm<<","<<opt.Omega_b<<","<<opt.Omega_Lambda<<")"<<endl;
 
     //number of DM particles
     //NOTE: this assumes a uniform box resolution. However this is not used in the rest of this function

--- a/src/substructureproperties.cxx
+++ b/src/substructureproperties.cxx
@@ -407,11 +407,11 @@ void GetCMProp(Options &opt, const Int_t nbodies, Particle *Part, Int_t ngroup, 
     Int_t ii,icmv;
     Int_t RV_num;
     Double_t virval=log(opt.virlevel*opt.rhobg);
-    Double_t m200val=log(opt.rhobg/opt.Omega_m*200.0);
+    Double_t m200val=log(opt.rhocrit*200.0);
     Double_t m200mval=log(opt.rhobg*200.0);
     Double_t mBN98val=log(opt.virBN98*opt.rhobg);
     //also calculate 500 overdensity and useful for gas/star content
-    Double_t m500val=log(opt.rhobg/opt.Omega_m*500.0);
+    Double_t m500val=log(opt.rhocrit*500.0);
 
     for (i=1;i<=ngroup;i++) {
         pdata[i].num=numingroup[i];
@@ -2214,9 +2214,9 @@ void GetInclusiveMasses(Options &opt, const Int_t nbodies, Particle *Part, Int_t
     Int_t ii,icmv,numinvir,num200c,num200m;
     Double_t virval=log(opt.virlevel*opt.rhobg);
     Double_t mBN98val=log(opt.virBN98*opt.rhobg);
-    Double_t m200val=log(opt.rhobg/opt.Omega_m*200.0);
+    Double_t m200val=log(opt.rhocrit*200.0);
     Double_t m200mval=log(opt.rhobg*200.0);
-    Double_t m500val=log(opt.rhobg/opt.Omega_m*500.0);
+    Double_t m500val=log(opt.rhocrit*500.0);
     Double_t fac,rhoval,rhoval2;
     Double_t time1=MyGetTime(),time2;
     int nthreads=1,tid;
@@ -4205,8 +4205,8 @@ void CalcCriticalDensity(Options &opt, Double_t a){
     opt.rhocrit=3.*Hubble*Hubble/(8.0*M_PI*opt.G);
 }
 void CalcBackgroundDensity(Options &opt, Double_t a){
-    CalcCriticalDensity(opt, a);
-    opt.rhobg=opt.rhocrit*opt.Omega_m;
+    CalcCriticalDensity(opt, 1.0);
+    opt.rhobg=opt.rhocrit*opt.Omega_m/(a*a*a);
 }
 void CalcVirBN98(Options &opt, Double_t a){
     Double_t bnx=-(opt.Omega_k*pow(a,-2.0)+opt.Omega_Lambda)/(opt.Omega_k*pow(a,-2.0)+opt.Omega_m*pow(a,-3.0)+opt.Omega_Lambda);

--- a/src/substructureproperties.cxx
+++ b/src/substructureproperties.cxx
@@ -409,7 +409,7 @@ void GetCMProp(Options &opt, const Int_t nbodies, Particle *Part, Int_t ngroup, 
     Double_t virval=log(opt.virlevel*opt.rhobg);
     Double_t m200val=log(opt.rhocrit*200.0);
     Double_t m200mval=log(opt.rhobg*200.0);
-    Double_t mBN98val=log(opt.virBN98*opt.rhobg);
+    Double_t mBN98val=log(opt.virBN98*opt.rhocrit);
     //also calculate 500 overdensity and useful for gas/star content
     Double_t m500val=log(opt.rhocrit*500.0);
 
@@ -2213,7 +2213,7 @@ void GetInclusiveMasses(Options &opt, const Int_t nbodies, Particle *Part, Int_t
     Double_t change=MAXVALUE,tol=1e-2;
     Int_t ii,icmv,numinvir,num200c,num200m;
     Double_t virval=log(opt.virlevel*opt.rhobg);
-    Double_t mBN98val=log(opt.virBN98*opt.rhobg);
+    Double_t mBN98val=log(opt.virBN98*opt.rhocrit);
     Double_t m200val=log(opt.rhocrit*200.0);
     Double_t m200mval=log(opt.rhobg*200.0);
     Double_t m500val=log(opt.rhocrit*500.0);
@@ -4205,12 +4205,12 @@ void CalcCriticalDensity(Options &opt, Double_t a){
     opt.rhocrit=3.*Hubble*Hubble/(8.0*M_PI*opt.G);
 }
 void CalcBackgroundDensity(Options &opt, Double_t a){
-    CalcCriticalDensity(opt, 1.0);
-    opt.rhobg=opt.rhocrit*opt.Omega_m/(a*a*a);
+    Double_t Hubble=GetHubble(opt,1.0);
+    opt.rhobg=3.*Hubble*Hubble/(8.0*M_PI*opt.G)*opt.Omega_m/(a*a*a);
 }
 void CalcVirBN98(Options &opt, Double_t a){
     Double_t bnx=-(opt.Omega_k*pow(a,-2.0)+opt.Omega_Lambda)/(opt.Omega_k*pow(a,-2.0)+opt.Omega_m*pow(a,-3.0)+opt.Omega_Lambda);
-    opt.virBN98=(18.0*M_PI*M_PI+82.0*bnx-39*bnx*bnx)/opt.Omega_m;
+    opt.virBN98=(18.0*M_PI*M_PI+82.0*bnx-39*bnx*bnx);
 }
 void CalcCosmoParams(Options &opt, Double_t a){
     CalcOmegak(opt);

--- a/src/substructureproperties.cxx
+++ b/src/substructureproperties.cxx
@@ -4220,7 +4220,7 @@ void CalcCosmoParams(Options &opt, Double_t a){
 }
 
 Double_t GetHubble(Options &opt, Double_t a){
-    return opt.h*opt.H*sqrt(opt.Omega_k*pow(a,-2.0)+opt.Omega_m*pow(a,-3.0)+opt.Omega_r*pow(a,-3.0)+opt.Omega_Lambda+opt.Omega_de*pow(a,-3.0*(1+opt.w_de)));
+    return opt.h*opt.H*sqrt(opt.Omega_k*pow(a,-2.0)+opt.Omega_m*pow(a,-3.0)+opt.Omega_r*pow(a,-4.0)+opt.Omega_Lambda+opt.Omega_de*pow(a,-3.0*(1+opt.w_de)));
 }
 
 double GetInvaH(double a, void * params) {

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -237,6 +237,7 @@ void SetVelociraptorSimulationState(cosmoinfo c, siminfo s)
         libvelociraptorOpt.ellxscale*=libvelociraptorOpt.a;
         libvelociraptorOpt.uinfo.eps*=libvelociraptorOpt.a;
 
+        /*
         Hubble=libvelociraptorOpt.h*libvelociraptorOpt.H*sqrt(libvelociraptorOpt.Omega_k*pow(libvelociraptorOpt.a,-2.0)+libvelociraptorOpt.Omega_m*pow(libvelociraptorOpt.a,-3.0)
 +libvelociraptorOpt.Omega_r*pow(libvelociraptorOpt.a,-4.0)+libvelociraptorOpt.Omega_Lambda+libvelociraptorOpt.Omega_de*pow(libvelociraptorOpt.a,-3.0*(1+libvelociraptorOpt.w_de)));
         libvelociraptorOpt.rhobg=3.*Hubble*Hubble/(8.0*M_PI*libvelociraptorOpt.G)*libvelociraptorOpt.Omega_m;
@@ -246,6 +247,14 @@ void SetVelociraptorSimulationState(cosmoinfo c, siminfo s)
             Double_t bnx=-(libvelociraptorOpt.Omega_k*pow(libvelociraptorOpt.a,-2.0)+libvelociraptorOpt.Omega_Lambda)/((1-libvelociraptorOpt.Omega_m-libvelociraptorOpt.Omega_Lambda)*pow(libvelociraptorOpt.a,-2.0)+libvelociraptorOpt.Omega_m*pow(libvelociraptorOpt.a,-3.0)+libvelociraptorOpt.Omega_Lambda);
             libvelociraptorOpt.virlevel=(18.0*M_PI*M_PI+82.0*bnx-39*bnx*bnx)/libvelociraptorOpt.Omega_m;
         }
+        */
+        CalcOmegak(libvelociraptorOpt);
+        Hubble=GetHubble(libvelociraptorOpt, libvelociraptorOpt.a);
+        CalcCriticalDensity(libvelociraptorOpt, libvelociraptorOpt.a);
+        CalcBackgroundDensity(libvelociraptorOpt, libvelociraptorOpt.a);
+        CalcVirBN98(libvelociraptorOpt,libvelociraptorOpt.a);
+        if (libvelociraptorOpt.virlevel<0) libvelociraptorOpt.virlevel=libvelociraptorOpt.virBN98;
+
         for (auto i=0;i<3;i++) {
             libvelociraptorOpt.spacedimension[i] *= libvelociraptorOpt.a;
             libvelociraptorOpt.cellwidth[i] *= libvelociraptorOpt.a;
@@ -253,6 +262,7 @@ void SetVelociraptorSimulationState(cosmoinfo c, siminfo s)
         }
     }
     else {
+        libvelociraptorOpt.rhocrit=1.0;
         libvelociraptorOpt.rhobg=1.0;
     }
     PrintSimulationState(libvelociraptorOpt);

--- a/src/ui.cxx
+++ b/src/ui.cxx
@@ -485,18 +485,24 @@ void GetParamFile(Options &opt)
                         opt.a = atof(vbuff);
                     else if (strcmp(tbuff, "h_val")==0)
                         opt.h = atof(vbuff);
-                    else if (strcmp(tbuff, "Omega_m")==0)
-                        opt.Omega_m = atof(vbuff);
-                    else if (strcmp(tbuff, "Omega_Lambda")==0)
-                        opt.Omega_Lambda = atof(vbuff);
                     else if (strcmp(tbuff, "Critical_density")==0)
                         opt.rhobg = atof(vbuff);
                     else if (strcmp(tbuff, "Virial_density")==0)
                         opt.virlevel = atof(vbuff);
+                    else if (strcmp(tbuff, "Omega_m")==0)
+                        opt.Omega_m = atof(vbuff);
+                    else if (strcmp(tbuff, "Omega_Lambda")==0)
+                        opt.Omega_Lambda = atof(vbuff);
+                    else if (strcmp(tbuff, "Omega_DE")==0)
+                        opt.Omega_de = atof(vbuff);
                     else if (strcmp(tbuff, "Omega_cdm")==0)
                         opt.Omega_cdm= atof(vbuff);
                     else if (strcmp(tbuff, "Omega_b")==0)
                         opt.Omega_b= atof(vbuff);
+                    else if (strcmp(tbuff, "Omega_r")==0)
+                        opt.Omega_r= atof(vbuff);
+                    else if (strcmp(tbuff, "Omega_nu")==0)
+                        opt.Omega_nu= atof(vbuff);
                     else if (strcmp(tbuff, "w_of_DE")==0)
                         opt.w_de= atof(vbuff);
                     //so units can be specified to convert to kpc, km/s, solar mass


### PR DESCRIPTION
It might be best not to merge this immediately but I'm making a pull request to document this fix.

Here I've tried to cherry pick the changes from Pascal's expandedproperties branch which are needed to fix the incorrect m200 halo masses which Velociraptor was generating. The problem was that the density threshold used for the spherical mass estimates had an incorrect dependence on redshift so it diverged from the correct value as redshift increased. The calculation of the threshold was duplicated over the various read routines and the SWIFT interface. In the fixed version there's a single function to do the calculation.

So far I've checked that this generates the same m200 mean and critical mass functions as the EAGLE code at low and high redshift in the 25Mpc DMONLY box. I haven't tried running through the swift interface yet.