### PR TITLE
Return most bound particle indexes when running on the fly in Swift

### DIFF
--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -370,23 +370,22 @@ void SetVelociraptorSimulationState(cosmoinfo c, siminfo s)
 }
 
 ///\todo interface with swift is comoving positions, period, peculiar velocities and physical self-energy
-extern "C" Swift::groupinfo * InvokeVelociraptor(const int snapnum, char* outputname,
+extern "C" Swift::vr_return_data InvokeVelociraptor(const int snapnum, char* outputname,
     cosmoinfo c, siminfo s,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads, const int ireturngroupinfoflag, int *const numpartingroups
 )
 {
-    groupinfo *group_info = NULL;
     const size_t num_bh_parts = 0;
-    group_info = InvokeVelociraptorHydro(snapnum, outputname, c, s,
+    vr_return_data return_data = InvokeVelociraptorHydro(snapnum, outputname, c, s,
         num_gravity_parts, num_hydro_parts, num_star_parts, num_bh_parts,
         swift_parts, cell_node_ids,
         numthreads, ireturngroupinfoflag,
         numpartingroups);
-    return group_info;
+    return return_data;
 }
-groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
+vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     cosmoinfo c, siminfo s,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
@@ -417,6 +416,12 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
 #else
     nthreads=1;
 #endif
+
+    // Construct return value
+    vr_return_data return_data;
+    return_data.groupinfo = NULL;
+    return_data.num_most_bound = 0;
+    return_data.most_bound_index = NULL;
 
     libvelociraptorOpt.outname = outputname;
     libvelociraptorOpt.snapshotvalue = HALOIDSNVAL* snapnum;
@@ -524,7 +529,7 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
                 }
                 else {
                     cout<<"Unknown particle type found: index="<<i<<" type="<<swift_parts[i].type<<" while treating baryons differently. Exiting..."<<endl;
-                    return NULL;
+                    return return_data;
                 }
             }
         }
@@ -533,7 +538,7 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
         for(auto i=0; i<Nlocal; i++) {
             if (CheckSwiftPartType(swift_parts[i].type)){
                 cout<<ThisTask<< "Unknown particle type found: index="<<i<<" type="<<swift_parts[i].type<<" when loading particles. Exiting..."<<endl;
-                return NULL;
+                return return_data;
             }
             for (auto j=0;j<3;j++) swift_parts[i].x[j]*=libvelociraptorOpt.a;
             parts[i] = Particle(swift_parts[i]);
@@ -736,7 +741,7 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
         free(cell_node_ids);
         delete[] pfof;
         *numpartingroups=0;
-        return NULL;
+        return return_data;
     }
 
     //first sort so all particles in groups first
@@ -751,7 +756,7 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
         delete[] pfof;
         parts.clear();
         *numpartingroups=nig;
-        return NULL;
+        return return_data;
     }
 
     delete [] pfof;
@@ -781,7 +786,7 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
     group_info=NULL;
     if (nig>0)
     {
-        group_info = new groupinfo[nig];
+      group_info = new groupinfo[nig];
         for (auto i=istart;i<Nlocal;i++) {
             group_info[i-istart].index=parts[i].GetSwiftIndex();
             group_info[i-istart].groupid=parts[i].GetPID();
@@ -796,12 +801,15 @@ groupinfo *InvokeVelociraptorHydro(const int snapnum, char* outputname,
     free(cell_node_ids);
     parts.clear();
 
-    return group_info;
+    // Add groupinfo to struct to return
+    return_data.groupinfo = group_info;
+
+    return return_data;
 }
 
 
 ///\todo interface with swift is comoving positions, period, peculiar velocities and physical self-energy
-groupinfo *InvokeVelociraptorExtra(const int iextra, const int snapnum, char* outputname,
+vr_return_data InvokeVelociraptorExtra(const int iextra, const int snapnum, char* outputname,
     cosmoinfo c, siminfo s,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
@@ -809,21 +817,20 @@ groupinfo *InvokeVelociraptorExtra(const int iextra, const int snapnum, char* ou
     const int ireturngroupinfoflag,
     int * const numpartingroups)
 {
-    groupinfo *group_info = NULL;
     //store backup of the libvelociraptorOpt
     libvelociraptorOptbackup = libvelociraptorOpt;
     libvelociraptorOpt = libvelociraptorOptextra[iextra];
-    group_info = InvokeVelociraptor(snapnum, outputname, c, s,
+    vr_return_data return_data = InvokeVelociraptor(snapnum, outputname, c, s,
         num_gravity_parts, num_hydro_parts, num_star_parts,
         swift_parts, cell_node_ids,
         numthreads,
         ireturngroupinfoflag,
         numpartingroups);
     libvelociraptorOpt = libvelociraptorOptbackup;
-    return group_info;
+    return return_data;
 }
 
-groupinfo *InvokeVelociraptorHydroExtra(const int iextra, const int snapnum, char* outputname,
+vr_return_data InvokeVelociraptorHydroExtra(const int iextra, const int snapnum, char* outputname,
     cosmoinfo c, siminfo s,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
@@ -835,17 +842,16 @@ groupinfo *InvokeVelociraptorHydroExtra(const int iextra, const int snapnum, cha
     struct swift_vel_bh_part *swift_bh_parts
 )
 {
-    groupinfo *group_info = NULL;
     //store backup of the libvelociraptorOpt
     libvelociraptorOptbackup = libvelociraptorOpt;
     libvelociraptorOpt = libvelociraptorOptextra[iextra];
-    group_info = InvokeVelociraptorHydro(snapnum, outputname, c, s,
+    vr_return_data return_data = InvokeVelociraptorHydro(snapnum, outputname, c, s,
         num_gravity_parts, num_hydro_parts, num_star_parts, num_bh_parts,
         swift_parts, cell_node_ids, numthreads, ireturngroupinfoflag,
         numpartingroups,
         swift_gas_parts, swift_star_parts, swift_bh_parts);
     libvelociraptorOpt = libvelociraptorOptbackup;
-    return group_info;
+    return return_data;
 }
 
 void CheckSwiftTasks(string message, const Int_t n, Particle *p){

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -786,7 +786,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     group_info=NULL;
     if (nig>0)
     {
-      group_info = new groupinfo[nig];
+      group_info = (groupinfo *) malloc(nig*sizeof(struct groupinfo)); // Will be freed by Swift
         for (auto i=istart;i<Nlocal;i++) {
             group_info[i-istart].index=parts[i].GetSwiftIndex();
             group_info[i-istart].groupid=parts[i].GetPID();

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -374,14 +374,14 @@ extern "C" Swift::vr_return_data InvokeVelociraptor(const int snapnum, char* out
     cosmoinfo c, siminfo s,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag
+    const int numthreads, const int ireturngroupinfoflag, const int ireturnmostbound
 )
 {
     const size_t num_bh_parts = 0;
     vr_return_data return_data = InvokeVelociraptorHydro(snapnum, outputname, c, s,
         num_gravity_parts, num_hydro_parts, num_star_parts, num_bh_parts,
         swift_parts, cell_node_ids,
-        numthreads, ireturngroupinfoflag);
+        numthreads, ireturngroupinfoflag, ireturnmostbound);
     return return_data;
 }
 vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
@@ -389,7 +389,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads,
-    const int ireturngroupinfoflag,
+    const int ireturngroupinfoflag, const int ireturnmostbound,
     struct swift_vel_gas_part *swift_gas_parts,
     struct swift_vel_star_part *swift_star_parts,
     struct swift_vel_bh_part *swift_bh_parts
@@ -812,7 +812,7 @@ vr_return_data InvokeVelociraptorExtra(const int iextra, const int snapnum, char
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads,
-    const int ireturngroupinfoflag)
+    const int ireturngroupinfoflag, const int ireturnmostbound)
 {
     //store backup of the libvelociraptorOpt
     libvelociraptorOptbackup = libvelociraptorOpt;
@@ -821,7 +821,7 @@ vr_return_data InvokeVelociraptorExtra(const int iextra, const int snapnum, char
         num_gravity_parts, num_hydro_parts, num_star_parts,
         swift_parts, cell_node_ids,
         numthreads,
-        ireturngroupinfoflag);
+        ireturngroupinfoflag, ireturnmostbound);
     libvelociraptorOpt = libvelociraptorOptbackup;
     return return_data;
 }
@@ -831,7 +831,7 @@ vr_return_data InvokeVelociraptorHydroExtra(const int iextra, const int snapnum,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads,
-    const int ireturngroupinfoflag,
+    const int ireturngroupinfoflag, const int ireturnmostbound,
     struct swift_vel_gas_part *swift_gas_parts,
     struct swift_vel_star_part *swift_star_parts,
     struct swift_vel_bh_part *swift_bh_parts
@@ -842,7 +842,7 @@ vr_return_data InvokeVelociraptorHydroExtra(const int iextra, const int snapnum,
     libvelociraptorOpt = libvelociraptorOptextra[iextra];
     vr_return_data return_data = InvokeVelociraptorHydro(snapnum, outputname, c, s,
         num_gravity_parts, num_hydro_parts, num_star_parts, num_bh_parts,
-        swift_parts, cell_node_ids, numthreads, ireturngroupinfoflag,
+        swift_parts, cell_node_ids, numthreads, ireturngroupinfoflag, ireturnmostbound,
         swift_gas_parts, swift_star_parts, swift_bh_parts);
     libvelociraptorOpt = libvelociraptorOptbackup;
     return return_data;

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -415,10 +415,10 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     nthreads=1;
 #endif
 
-    // Construct return value
+    // Construct default return value
     vr_return_data return_data;
-    return_data.numingroups = 0;
-    return_data.groupinfo = NULL;
+    return_data.num_gparts_in_groups = 0;
+    return_data.group_info = NULL;
     return_data.num_most_bound = 0;
     return_data.most_bound_index = NULL;
 
@@ -753,7 +753,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
         free(cell_node_ids);
         delete[] pfof;
         parts.clear();
-        return_data.numingroups=nig;
+        return_data.num_gparts_in_groups=nig;
         return return_data;
     }
 
@@ -780,7 +780,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     nig=0;
     Int_t istart=0;
     for (auto i=0;i<Nlocal;i++) if (parts[i].GetPID()>0) {nig=Nlocal-i;istart=i;break;}
-    return_data.numingroups=nig;
+    return_data.num_gparts_in_groups=nig;
     group_info=NULL;
     if (nig>0)
     {
@@ -800,7 +800,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     parts.clear();
 
     // Add groupinfo to struct to return
-    return_data.groupinfo = group_info;
+    return_data.group_info = group_info;
 
     return return_data;
 }

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -715,7 +715,6 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
       }
     }
 
-    for (Int_t i=1;i<=ngroup;i++) delete[] pglist[i];
     delete[] pdata;
     delete[] nsub;
     delete[] uparentgid;
@@ -762,6 +761,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     return_data.num_most_bound = num_most_bound;
     return_data.most_bound_index = most_bound_index;
 
+    for (Int_t i=1;i<=ngroup;i++) delete[] pglist[i];
     delete[] pglist;
     delete[] numingroup;
 

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -374,15 +374,14 @@ extern "C" Swift::vr_return_data InvokeVelociraptor(const int snapnum, char* out
     cosmoinfo c, siminfo s,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag, int *const numpartingroups
+    const int numthreads, const int ireturngroupinfoflag
 )
 {
     const size_t num_bh_parts = 0;
     vr_return_data return_data = InvokeVelociraptorHydro(snapnum, outputname, c, s,
         num_gravity_parts, num_hydro_parts, num_star_parts, num_bh_parts,
         swift_parts, cell_node_ids,
-        numthreads, ireturngroupinfoflag,
-        numpartingroups);
+        numthreads, ireturngroupinfoflag);
     return return_data;
 }
 vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
@@ -391,7 +390,6 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads,
     const int ireturngroupinfoflag,
-    int * const numpartingroups,
     struct swift_vel_gas_part *swift_gas_parts,
     struct swift_vel_star_part *swift_star_parts,
     struct swift_vel_bh_part *swift_bh_parts
@@ -419,6 +417,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
 
     // Construct return value
     vr_return_data return_data;
+    return_data.numingroups = 0;
     return_data.groupinfo = NULL;
     return_data.num_most_bound = 0;
     return_data.most_bound_index = NULL;
@@ -740,7 +739,6 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
         free(s.cellloc);
         free(cell_node_ids);
         delete[] pfof;
-        *numpartingroups=0;
         return return_data;
     }
 
@@ -755,7 +753,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
         free(cell_node_ids);
         delete[] pfof;
         parts.clear();
-        *numpartingroups=nig;
+        return_data.numingroups=nig;
         return return_data;
     }
 
@@ -782,7 +780,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     nig=0;
     Int_t istart=0;
     for (auto i=0;i<Nlocal;i++) if (parts[i].GetPID()>0) {nig=Nlocal-i;istart=i;break;}
-    *numpartingroups=nig;
+    return_data.numingroups=nig;
     group_info=NULL;
     if (nig>0)
     {
@@ -814,8 +812,7 @@ vr_return_data InvokeVelociraptorExtra(const int iextra, const int snapnum, char
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads,
-    const int ireturngroupinfoflag,
-    int * const numpartingroups)
+    const int ireturngroupinfoflag)
 {
     //store backup of the libvelociraptorOpt
     libvelociraptorOptbackup = libvelociraptorOpt;
@@ -824,8 +821,7 @@ vr_return_data InvokeVelociraptorExtra(const int iextra, const int snapnum, char
         num_gravity_parts, num_hydro_parts, num_star_parts,
         swift_parts, cell_node_ids,
         numthreads,
-        ireturngroupinfoflag,
-        numpartingroups);
+        ireturngroupinfoflag);
     libvelociraptorOpt = libvelociraptorOptbackup;
     return return_data;
 }
@@ -836,7 +832,6 @@ vr_return_data InvokeVelociraptorHydroExtra(const int iextra, const int snapnum,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads,
     const int ireturngroupinfoflag,
-    int * const numpartingroups,
     struct swift_vel_gas_part *swift_gas_parts,
     struct swift_vel_star_part *swift_star_parts,
     struct swift_vel_bh_part *swift_bh_parts
@@ -848,7 +843,6 @@ vr_return_data InvokeVelociraptorHydroExtra(const int iextra, const int snapnum,
     vr_return_data return_data = InvokeVelociraptorHydro(snapnum, outputname, c, s,
         num_gravity_parts, num_hydro_parts, num_star_parts, num_bh_parts,
         swift_parts, cell_node_ids, numthreads, ireturngroupinfoflag,
-        numpartingroups,
         swift_gas_parts, swift_star_parts, swift_bh_parts);
     libvelociraptorOpt = libvelociraptorOptbackup;
     return return_data;

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -716,17 +716,54 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     }
 
     for (Int_t i=1;i<=ngroup;i++) delete[] pglist[i];
-    delete[] pglist;
     delete[] pdata;
     delete[] nsub;
     delete[] uparentgid;
     delete[] parentgid;
     delete[] stype;
     delete psldata;
-    delete[] numingroup;
 
     //get memory usage
     GetMemUsage(libvelociraptorOpt, __func__+string("--line--")+to_string(__LINE__), true);
+
+    // Make array of most bound particle indexes if we have groups and it was requested
+    Int_t num_most_bound = 0;
+    int *most_bound_index = NULL;
+    if(ireturnmostbound && ngtot > 0) {
+      
+      // Make a vector containing just the most bound particle from each non-zero size group
+      vector<Particle> most_bound_parts;
+      most_bound_parts.reserve(ngroup);
+      for (auto i=1; i<=ngroup; i++) {
+        if(numingroup[i] > 0)most_bound_parts.push_back(parts[pglist[i][0]]);
+      }
+      num_most_bound = most_bound_parts.size();
+
+      // Send each most bound particle to the MPI rank it was on in Swift
+#ifdef USEMPI
+      if (NProcs > 1) {
+        for (auto i=0;i<num_most_bound; i++) most_bound_parts[i].SetID((most_bound_parts[i].GetSwiftTask()!=ThisTask));
+        //now sort items according to whether local swift task
+        qsort(most_bound_parts.data(), num_most_bound, sizeof(Particle), IDCompare);
+        //communicate information
+        MPISwiftExchange(most_bound_parts);
+        num_most_bound = most_bound_parts.size();
+      }
+#endif
+      // Make an array with the Swift indexes of the most bound particles.
+      // This will be returned to Swift so it has to be allocated with malloc().
+      most_bound_index = (int *) malloc(sizeof(int)*num_most_bound);
+      for (auto i=0;i<num_most_bound; i++) {
+        most_bound_index[i] = most_bound_parts[i].GetSwiftIndex();
+      }
+      most_bound_parts.clear();
+    }
+    // Add most bound particles to struct to return
+    return_data.num_most_bound = num_most_bound;
+    return_data.most_bound_index = most_bound_index;
+
+    delete[] pglist;
+    delete[] numingroup;
 
     // Compute group_info array if we have groups and it was requested
     groupinfo *group_info = NULL;
@@ -741,14 +778,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
         qsort(parts.data(), Nlocal, sizeof(Particle), IDCompare);
         //communicate information
         MPISwiftExchange(parts);
-        Nlocal = parts.size();
-        
-        for (auto i=0;i<Nlocal; i++) {
-          if(parts[i].GetSwiftTask() != ThisTask) {
-            cout << "Particle on wrong task!";
-            MPI_Abort(MPI_COMM_WORLD, 1);
-          }
-        } 
+        Nlocal = parts.size(); 
       }
 #endif
       qsort(parts.data(), Nlocal, sizeof(Particle), PIDCompare);
@@ -768,8 +798,6 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     return_data.num_gparts_in_groups=nig;
     return_data.group_info = group_info;
 
-    cout<<"VELOCIraptor returning."<< endl;
-
     //free mem associate with mpi cell node ides
     libvelociraptorOpt.cellnodeids = NULL;
     libvelociraptorOpt.cellloc = NULL;
@@ -777,6 +805,7 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     free(cell_node_ids);
     parts.clear();
 
+    cout<<"VELOCIraptor returning."<< endl;
     return return_data;
 }
 

--- a/src/swiftinterface.h
+++ b/src/swiftinterface.h
@@ -128,6 +128,8 @@ namespace Swift {
 
     // Data returned when invoking Velociraptor
     struct vr_return_data {
+      // Number of gparts in groups
+      int numingroups;
       // Pointer to group information array, or NULL if not requested
       struct groupinfo *groupinfo;
       // Number of most bound particles returned
@@ -152,13 +154,13 @@ extern "C" Swift::vr_return_data InvokeVelociraptor(const int snapnum, char* out
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag, int *const numingroups
+    const int numthreads, const int ireturngroupinfoflag
 );
 extern "C" Swift::vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag, int *const numingroups,
+    const int numthreads, const int ireturngroupinfoflag,
     struct swift_vel_gas_part *swift_gas_parts = NULL,
     struct swift_vel_star_part *swift_star_parts = NULL,
     struct swift_vel_bh_part *swift_bh_parts = NULL
@@ -168,7 +170,7 @@ extern "C" Swift::vr_return_data InvokeVelociraptorExtra(const int iextra,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag, int *const numingroups
+    const int numthreads, const int ireturngroupinfoflag
 );
 extern "C" Swift::vr_return_data InvokeVelociraptorHydroExtra(const int iextra,
     const int snapnum, char* outputname,
@@ -176,7 +178,7 @@ extern "C" Swift::vr_return_data InvokeVelociraptorHydroExtra(const int iextra,
     const size_t num_gravity_parts, const size_t num_hydro_parts,
     const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag, int *const numingroups,
+    const int numthreads, const int ireturngroupinfoflag,
     struct swift_vel_gas_part *swift_gas_parts = NULL,
     struct swift_vel_star_part *swift_star_parts = NULL,
     struct swift_vel_bh_part *swift_bh_parts = NULL

--- a/src/swiftinterface.h
+++ b/src/swiftinterface.h
@@ -125,6 +125,16 @@ namespace Swift {
       int index;
       long long groupid;
     };
+
+    // Data returned when invoking Velociraptor
+    struct vr_return_data {
+      // Pointer to group information array, or NULL if not requested
+      struct groupinfo *groupinfo;
+      // Number of most bound particles returned
+      int num_most_bound;
+      // Swift gpart indexes of most bound particles, or NULL if not requested
+      int *most_bound_index;
+    };
 }
 
 
@@ -138,13 +148,13 @@ extern "C" int InitVelociraptor(char* configname, Swift::unitinfo, Swift::siminf
 ///initialize velociraptor based on extra possible outputs requested by swift in addition to standard invocation, check configuration options,
 extern "C" int InitVelociraptorExtra(const int iextra, char* configname, Swift::unitinfo, Swift::siminfo, const int numthreads);
 ///actually run velociraptor
-extern "C" Swift::groupinfo * InvokeVelociraptor(const int snapnum, char* outputname,
+extern "C" Swift::vr_return_data InvokeVelociraptor(const int snapnum, char* outputname,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads, const int ireturngroupinfoflag, int *const numingroups
 );
-extern "C" Swift::groupinfo * InvokeVelociraptorHydro(const int snapnum, char* outputname,
+extern "C" Swift::vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
@@ -153,14 +163,14 @@ extern "C" Swift::groupinfo * InvokeVelociraptorHydro(const int snapnum, char* o
     struct swift_vel_star_part *swift_star_parts = NULL,
     struct swift_vel_bh_part *swift_bh_parts = NULL
 );
-extern "C" Swift::groupinfo * InvokeVelociraptorExtra(const int iextra,
+extern "C" Swift::vr_return_data InvokeVelociraptorExtra(const int iextra,
     const int snapnum, char* outputname,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads, const int ireturngroupinfoflag, int *const numingroups
 );
-extern "C" Swift::groupinfo * InvokeVelociraptorHydroExtra(const int iextra,
+extern "C" Swift::vr_return_data InvokeVelociraptorHydroExtra(const int iextra,
     const int snapnum, char* outputname,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts,

--- a/src/swiftinterface.h
+++ b/src/swiftinterface.h
@@ -154,13 +154,13 @@ extern "C" Swift::vr_return_data InvokeVelociraptor(const int snapnum, char* out
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag
+    const int numthreads, const int ireturngroupinfoflag, const int ireturnmostbound
 );
 extern "C" Swift::vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag,
+    const int numthreads, const int ireturngroupinfoflag, const int ireturnmostbound,
     struct swift_vel_gas_part *swift_gas_parts = NULL,
     struct swift_vel_star_part *swift_star_parts = NULL,
     struct swift_vel_bh_part *swift_bh_parts = NULL
@@ -170,7 +170,7 @@ extern "C" Swift::vr_return_data InvokeVelociraptorExtra(const int iextra,
     Swift::cosmoinfo, Swift::siminfo,
     const size_t num_gravity_parts, const size_t num_hydro_parts, const size_t num_star_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
-    const int numthreads, const int ireturngroupinfoflag
+    const int numthreads, const int ireturngroupinfoflag, const int ireturnmostbound
 );
 extern "C" Swift::vr_return_data InvokeVelociraptorHydroExtra(const int iextra,
     const int snapnum, char* outputname,
@@ -179,6 +179,7 @@ extern "C" Swift::vr_return_data InvokeVelociraptorHydroExtra(const int iextra,
     const size_t num_star_parts, const size_t num_bh_parts,
     struct swift_vel_part *swift_parts, int *cell_node_ids,
     const int numthreads, const int ireturngroupinfoflag,
+    const int ireturnmostbound,
     struct swift_vel_gas_part *swift_gas_parts = NULL,
     struct swift_vel_star_part *swift_star_parts = NULL,
     struct swift_vel_bh_part *swift_bh_parts = NULL

--- a/src/swiftinterface.h
+++ b/src/swiftinterface.h
@@ -129,9 +129,9 @@ namespace Swift {
     // Data returned when invoking Velociraptor
     struct vr_return_data {
       // Number of gparts in groups
-      int numingroups;
+      int num_gparts_in_groups;
       // Pointer to group information array, or NULL if not requested
-      struct groupinfo *groupinfo;
+      struct groupinfo *group_info;
       // Number of most bound particles returned
       int num_most_bound;
       // Swift gpart indexes of most bound particles, or NULL if not requested


### PR DESCRIPTION
This modifies the Swift interface so that Swift can request that Velociraptor return the indexes of the most bound particles in the halos it finds. On the Swift side, we can then use that information to output the particles we need for 'orphan' galaxies in semi-analytic models (i.e. galaxies which are no longer associated with a resolved halo.)

The corresponding merge request on the Swift side is at https://gitlab.cosma.dur.ac.uk/swift/swiftsim/merge_requests/1131.

(moved over from Pascal's repository)