### PR TITLE
Update to implement specific particle types for min potential reference

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -464,6 +464,10 @@ Configuration options related to the bulk properties calculated.
             - **2** use the position of the particle with the minimum potential.
             - **1** use the position of the most bound particle.
             - **0** use the centre-of-mass.
+    ``Particle_type_for_reference_frames = -1``
+        * Flag indicating what particle type is used to determine the minimum potential reference position.
+            - **-1** all particle types
+            - **0-6** other int correspond to a specific particle type. For instance 1 would be dark matter particles 
     ``Extensive_halo_properties_output = 1``
         * Flag indicating that one should calculate more properties for objects, such as angular momentum in spherical overdensity apertures.
     ``Extensive_gas_properties_output = 1``

--- a/examples/sample_swifthydro_3dfof_subhalo_extra_properties.cfg
+++ b/examples/sample_swifthydro_3dfof_subhalo_extra_properties.cfg
@@ -205,6 +205,7 @@ Inclusive_halo_masses=3 #calculate inclusive masses for halos using full Spheric
 Iterate_cm_flag=0 #do not interatively find the centre-of-mass, giving bulk centre of mass and centre of mass velocity.
 Sort_by_binding_energy=1 #sort by binding energy
 Reference_frame_for_properties=2 #use the position of the particle with the minimum potential as the point about which properties should be calculated.
+Particle_type_for_reference_frames=-1 #minimum potential reference frame based on particles of type -1 (all particles). Could set to 1 to use only dark matter particles
 #calculate more (sub)halo properties (like angular momentum in spherical overdensity apertures, both inclusive and exclusive)
 Extensive_halo_properties_output=1
 Extensive_gas_properties_output=1

--- a/src/substructureproperties.cxx
+++ b/src/substructureproperties.cxx
@@ -9,8 +9,8 @@
 //@{
 
 inline bool CheckForSOSubCalc(Options &opt, PropData &pdata) {
-    return (opt.iInclusiveHalo==0 || opt.iInclusiveHalo!=0 && pdata.hostid!=-1 &&
-        pdata.stype > opt.SphericalOverdensitySeachMaxStructLevel);
+    return (opt.iInclusiveHalo==0 || (opt.iInclusiveHalo!=0 && pdata.hostid!=-1 &&
+        pdata.stype > opt.SphericalOverdensitySeachMaxStructLevel));
 }
 
 inline bool CheckForSOExclCalc(Options &opt, PropData &pdata) {
@@ -4327,11 +4327,15 @@ private(i,j,k,r2,v2,poti,Ti,pot,Eval,npot,storepid,menc,potmin,ipotmin,cmpotmin)
             //determine position of minimum potential and by radius around this position
             potmin=Part[noffset[i]].GetPotential()/Part[noffset[i]].GetMass();
             ipotmin=0;
-            for (j=0;j<numingroup[i];j++) if (Part[j+noffset[i]].GetPotential()/Part[j+noffset[i]].GetMass()<potmin)
+            for (j=0;j<numingroup[i];j++)
             {
                 if (opt.ParticleTypeForRefenceFrame !=-1 && Part[noffset[i]+j].GetType() != opt.ParticleTypeForRefenceFrame) continue;
-                potmin=Part[j+noffset[i]].GetPotential()/Part[j+noffset[i]].GetMass();
-                ipotmin=j;
+                auto potcur = Part[j+noffset[i]].GetPotential()/Part[j+noffset[i]].GetMass();
+                if (potcur<potmin)
+                {
+                    potmin=potcur;
+                    ipotmin=j;
+                }
             }
             pdata[i].iminpot=Part[ipotmin+noffset[i]].GetPID();
             for (k=0;k<3;k++)
@@ -4370,11 +4374,15 @@ private(i,j,k,potmin,ipotmin)
     for (i=1;i<=ngroup;i++) if (numingroup[i]<ompunbindnum) {
         potmin=Part[noffset[i]].GetPotential()/Part[noffset[i]].GetMass();
         ipotmin=0;
-        for (j=0;j<numingroup[i];j++) if (Part[j+noffset[i]].GetPotential()/Part[j+noffset[i]].GetMass()<potmin)
+        for (j=0;j<numingroup[i];j++)
         {
             if (opt.ParticleTypeForRefenceFrame !=-1 && Part[noffset[i]+j].GetType() != opt.ParticleTypeForRefenceFrame) continue;
-            potmin=Part[j+noffset[i]].GetPotential()/Part[j+noffset[i]].GetMass();
-            ipotmin=j;
+            auto potcur = Part[j+noffset[i]].GetPotential()/Part[j+noffset[i]].GetMass();
+            if (potcur<potmin)
+            {
+                potmin=potcur;
+                ipotmin=j;
+            }
         }
         pdata[i].iminpot=Part[ipotmin+noffset[i]].GetPID();
         for (k=0;k<3;k++)
@@ -4403,11 +4411,15 @@ private(i,j,k,r2,v2,poti,Ti,pot,Eval,npot,storepid,menc,potmin,ipotmin,cmpotmin)
             //determine position of minimum potential and by radius around this position
             potmin=Part[noffset[i]].GetPotential()/Part[noffset[i]].GetMass();
             ipotmin=0;
-            for (j=0;j<numingroup[i];j++) if (Part[j+noffset[i]].GetPotential()/Part[j+noffset[i]].GetMass()<potmin)
+            for (j=0;j<numingroup[i];j++)
             {
                 if (opt.ParticleTypeForRefenceFrame !=-1 && Part[noffset[i]+j].GetType() != opt.ParticleTypeForRefenceFrame) continue;
-                potmin=Part[j+noffset[i]].GetPotential()/Part[j+noffset[i]].GetMass();
-                ipotmin=j;
+                auto potcur = Part[j+noffset[i]].GetPotential()/Part[j+noffset[i]].GetMass();
+                if (potcur < potmin)
+                {
+                    potmin=potcur;
+                    ipotmin=j;
+                }
             }
             pdata[i].iminpot=Part[ipotmin+noffset[i]].GetPID();
             for (k=0;k<3;k++)
@@ -4445,11 +4457,15 @@ private(i,j,k,potmin,ipotmin)
     for (i=1;i<=ngroup;i++) if (numingroup[i]>=ompunbindnum) {
         potmin=Part[noffset[i]].GetPotential()/Part[noffset[i]].GetMass();
         ipotmin=0;
-        for (j=0;j<numingroup[i];j++) if (Part[j+noffset[i]].GetPotential()/Part[j+noffset[i]].GetMass()<potmin)
+        for (j=0;j<numingroup[i];j++)
         {
             if (opt.ParticleTypeForRefenceFrame !=-1 && Part[noffset[i]+j].GetType() != opt.ParticleTypeForRefenceFrame) continue;
-            potmin=Part[j+noffset[i]].GetPotential()/Part[j+noffset[i]].GetMass();
-            ipotmin=j;
+            auto potcur = Part[j+noffset[i]].GetPotential()/Part[j+noffset[i]].GetMass();
+            if (potcur<potmin)
+            {
+                potmin=potcur;
+                ipotmin=j;
+            }
         }
         pdata[i].iminpot=Part[ipotmin+noffset[i]].GetPID();
         for (k=0;k<3;k++) {pdata[i].gposminpot[k]=Part[ipotmin+noffset[i]].GetPosition(k);pdata[i].gvelminpot[k]=Part[ipotmin+noffset[i]].GetVelocity(k);}


### PR DESCRIPTION
Updated example file to highlight parameter that sets the reference particle type.

To be tested first by ICRAR test team, only then it will be merged back into `master`.