### PR TITLE
Fix opening of extra properties' HDF5 objects

### DIFF
--- a/src/hdfio.cxx
+++ b/src/hdfio.cxx
@@ -2347,9 +2347,6 @@ void ReadHDF(Options &opt, vector<Particle> &Part, const Int_t nbodies,Particle 
                     {
                         k=usetypes[j];
                         if (k!=HDFGASTYPE) {
-                            iextraoffset += opt.gas_internalprop_names.size() +
-                                opt.gas_chem_names.size() +
-                                opt.gas_chemproduction_names.size();
                             continue;
                         }
                         if (opt.gas_internalprop_names.size()>0)
@@ -2395,9 +2392,6 @@ void ReadHDF(Options &opt, vector<Particle> &Part, const Int_t nbodies,Particle 
                     {
                         k=usetypes[j];
                         if (k!=HDFSTARTYPE) {
-                            iextraoffset += opt.star_internalprop_names.size() +
-                                opt.star_chem_names.size() +
-                                opt.star_chemproduction_names.size();
                             continue;
                         }
                         if (opt.star_internalprop_names.size()>0)
@@ -2443,9 +2437,6 @@ void ReadHDF(Options &opt, vector<Particle> &Part, const Int_t nbodies,Particle 
                     {
                         k=usetypes[j];
                         if (k!=HDFBHTYPE) {
-                            iextraoffset += opt.bh_internalprop_names.size() +
-                                opt.bh_chem_names.size() +
-                                opt.bh_chemproduction_names.size();
                             continue;
                         }
                         if (opt.bh_internalprop_names.size()>0)


### PR DESCRIPTION
When HDF5 datasets and dataspaces for the extra properties indicated by
the user (gas/bh/star) are opened, their IDs are stored in two
corresponding vectors that are previously sized to hold exactly the
number of extra properties that are required. However, the code
incorrectly added some offsets to the indices used when storing the IDs
in the vectors, writing past the vectors' end.

This commit fixes the calculation of the indices, removing the
additional offsets added when certain conditions are not met, yielding
index values within the vectors' size boundaries.

Note that when these IDs were accessed later on, the indices used for
that access operation were correctly calculated. This gave a wrong
initial impression that *those* indices were wrong, while in reality it
was the "opening" indices that were wrong.

This should address the problem reported in #15.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>