### PR TITLE
Remove double as return type of ExtraPropFunc

### DIFF
--- a/src/allvars.h
+++ b/src/allvars.h
@@ -229,7 +229,7 @@ using namespace NBody;
 #define CALCLOGSTDMASSWEIGHT 18
 #define CALCQUANTITYAPERTURETOTAL -1
 #define CALCQUANTITYAPERTUREAVERAGE -2
-typedef double (*ExtraPropFunc)(double, double, double&);
+typedef void (*ExtraPropFunc)(double, double, double&);
 
 //@}
 

--- a/src/substructureproperties.cxx
+++ b/src/substructureproperties.cxx
@@ -5902,26 +5902,26 @@ inline double ExtraPropGetWeight(unsigned int calctype, double weight){
     if (calctype < CALCQUANTITYMASSWEIGHT) weight = 1.0;
     return weight;
 }
-inline double ExtraPropCalcAverage(double weight, double value, double &result){
+inline void ExtraPropCalcAverage(double weight, double value, double &result){
     result += value * weight;
 }
-inline double ExtraPropCalcTotal(double weight, double value, double &result){
+inline void ExtraPropCalcTotal(double weight, double value, double &result){
     result += value * weight;
 }
-inline double ExtraPropCalcSTD(double weight, double value, double &result){
+inline void ExtraPropCalcSTD(double weight, double value, double &result){
     result += value * value * weight;
 }
-inline double ExtraPropCalcLogAverage(double weight, double value, double &result){
+inline void ExtraPropCalcLogAverage(double weight, double value, double &result){
     result += log(value) * weight;
 }
-inline double ExtraPropCalcLogSTD(double weight, double value, double &result){
+inline void ExtraPropCalcLogSTD(double weight, double value, double &result){
     value = log(value);
     result += value * value * weight;
 }
-inline double ExtraPropCalcMin(double weight, double value, double &result){
+inline void ExtraPropCalcMin(double weight, double value, double &result){
     if (value*weight < result) result = value * weight;
 }
-inline double ExtraPropCalcMax(double weight, double value, double &result){
+inline void ExtraPropCalcMax(double weight, double value, double &result){
     if (value*weight > result) result = value * weight;
 }
 inline double ExtraPropNormalizeValue(unsigned int calctype, double value, double norm){


### PR DESCRIPTION
The different functions calculating accumulated metrics over the extra
gas/star/bh properties shared a common signature (made explicitly by the
ExtraPropFunc typedef) signaling that a double value should be returned.
However, in reality none of these functions performed a return. This in
seems to have contributed to the introduction of UB, resulting in
hard-to-debug errors.

This commit modifies the ExtraPropFunc typedef to indicate that
functions adjusting to this type don't need to return a double, and
should return void instead. The signature of all the functions that are
used through this typedef are then adjusted to reflect this change.

Although it looks unrelated, this patch fixes the problem described in
issue #18. This is consistent with the fact that the problem surfaced
only after certain optimization levels were introduced, and with some of
debugging information shown by gdb (although at the time it wasn't
obvious what the problem was).

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>