### PR TITLE
Correcting ages to follow internal units of input

### DIFF
--- a/src/io.cxx
+++ b/src/io.cxx
@@ -165,11 +165,12 @@ void AdjustStarQuantities(Options &opt, vector<Particle> &Part, const Int_t nbod
             if (p.GetType()!=STARTYPE) continue;
             //if stellar age is initially stored as scale factor of formation
             if (opt.istellaragescalefactor == 1) {
-                tage = CalcCosmicTime(opt,p.GetTage(),opt.a);
+		//make sure units are consisten with those internal to the input tables as CalcCosmicTime returns time in yrs.
+                tage = CalcCosmicTime(opt,p.GetTage(),opt.a) / opt.stellaragetoyrs;
             }
             //if stellar age is initially stored as redshift of formation
             else if (opt.istellaragescalefactor == 2) {
-                tage = CalcCosmicTime(opt,1.0/(p.GetTage()+1),opt.a);
+                tage = CalcCosmicTime(opt,1.0/(p.GetTage()+1),opt.a) / opt.stellaragetoyrs;
             }
             //if stellar age is initially stored as time of formation
             else if (opt.istellaragescalefactor == 3) {


### PR DESCRIPTION
The function used CosmicTimeCalc returned the age in years and not the internal units of the input table. I corrected this by using
the parameter stellar_age_to_yr provided in the input parameter.