### PR TITLE
OpenMP 5 fixes

### DIFF
--- a/src/main.cxx
+++ b/src/main.cxx
@@ -71,6 +71,7 @@ int main(int argc,char **argv)
 #endif
 #ifdef USEOPENMP
     if (ThisTask==0) cout<<"VELOCIraptor/STF running with OpenMP. Number of openmp threads: "<<nthreads<<endl;
+    if (ThisTask==0) cout<<"VELOCIraptor/STF running with OpenMP version "<< _OPENMP << endl;
 #endif
 
     gsl_set_error_handler_off();

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -20,10 +20,6 @@ using namespace velociraptor;
 
 int main(int argc,char **argv)
 {
-#ifdef SWIFTINTERFACE
-    cout<<"Built with SWIFT interface enabled when running standalone VELOCIraptor. Should only be enabled when running VELOCIraptor as a library from SWIFT. Exiting..."<<endl;
-    exit(0);
-#endif
 #ifdef USEMPI
     //start MPI
 #ifdef USEOPENMP
@@ -72,6 +68,11 @@ int main(int argc,char **argv)
 #ifdef USEOPENMP
     if (ThisTask==0) cout<<"VELOCIraptor/STF running with OpenMP. Number of openmp threads: "<<nthreads<<endl;
     if (ThisTask==0) cout<<"VELOCIraptor/STF running with OpenMP version "<< _OPENMP << endl;
+#endif
+
+#ifdef SWIFTINTERFACE
+    cout<<"Built with SWIFT interface enabled when running standalone VELOCIraptor. Should only be enabled when running VELOCIraptor as a library from SWIFT. Exiting..."<<endl;
+    exit(0);
 #endif
 
     gsl_set_error_handler_off();


### PR DESCRIPTION
These are fixes to suppress warnings due to VR using `omp_{get,set}_nested`, which is deprecated in OpenMP 5. The fixes are mostly in NBodylib, which checks the compile-time OpenMP version (there's no way to check the runtime version) and decides whether to use the old functions, or the newer alternatives.

I took the chance of cleaning a bit the code around these function calls, trying to reduce duplication and mental load.