### PR TITLE
Correct output of multidimensional datasets when using parallel HDF5

### DIFF
--- a/src/hdfitems.h
+++ b/src/hdfitems.h
@@ -701,181 +701,25 @@ class H5OutputFile
 
 
     /// Write a multidimensional dataset. Data type of the new dataset is taken to be the type of
-    /// the input data if not explicitly specified with the filetype_id parameter.
+    /// the input data if not explicitly specified with the filetype_id parameter. This is just
+    /// a wrapper which uses the type of the supplied array to set the memtype_id parameter
+    /// if it's not set explicitly.
     template <typename T> void write_dataset_nd(Options opt, std::string name, int rank, hsize_t *dims, T *data,
         hid_t memtype_id = -1, hid_t filetype_id = -1,
         bool flag_parallel = true, bool flag_first_dim_parallel = true,
         bool flag_hyperslab = true, bool flag_collective = true)
     {
-#ifdef USEPARALLELHDF
-        MPI_Comm comm = mpi_comm_write;
-        MPI_Info info = MPI_INFO_NULL;
-#endif
-        hid_t dspace_id, dset_id, prop_id, memspace_id, ret;
-        vector<hsize_t> chunks(rank);
 
-        // Get HDF5 data type of the array in memory
-        if (memtype_id == -1) memtype_id = hdf5_type(T{});
+      // Get HDF5 data type of the array in memory
+      if (memtype_id == -1) memtype_id = hdf5_type(T{});
 
-        // Determine type of the dataset to create
-        if(filetype_id < 0) filetype_id = memtype_id;
-
-#ifdef USEPARALLELHDF
-        vector<unsigned long long> mpi_hdf_dims(rank*NProcsWrite), mpi_hdf_dims_tot(rank), dims_single(rank), dims_offset(rank);
-        if ((flag_parallel) & (opt.mpinprocswritesize>1)) {
-            //if parallel hdf5 get the full extent of the data
-            //this bit of code communicating information can probably be done elsewhere
-            //minimize number of mpi communications
-            for (auto i=0;i<rank;i++) dims_single[i]=dims[i];
-            MPI_Allgather(dims_single.data(), rank, MPI_UNSIGNED_LONG_LONG, mpi_hdf_dims.data(), rank, MPI_UNSIGNED_LONG_LONG, comm);
-            MPI_Allreduce(dims_single.data(), mpi_hdf_dims_tot.data(), rank, MPI_UNSIGNED_LONG_LONG, MPI_SUM, comm);
-            for (auto i=0;i<rank;i++) {
-                dims_offset[i] = 0;
-                if (flag_first_dim_parallel && i > 0) continue;
-                for (auto j=1;j<=ThisWriteTask;j++) {
-                    dims_offset[i] += mpi_hdf_dims[i*NProcs+j-1];
-                }
-            }
-            if (flag_first_dim_parallel && rank > 1) {
-                for (auto i=1; i<rank;i++) mpi_hdf_dims_tot[i] = dims[i];
-            }
-        }
-#endif
-
-        // Determine if going to compress data in chunks
-        // Only chunk non-zero size datasets
-        int nonzero_size = 1;
-        for(int i=0; i<rank; i++)
-        {
-#ifdef USEPARALLELHDF
-            if ((flag_parallel) & (opt.mpinprocswritesize>1)) {
-                if(mpi_hdf_dims_tot[i]==0) nonzero_size = 0;
-            }
-            else {
-                if(dims[i]==0) nonzero_size = 0;
-            }
-#else
-            if(dims[i]==0) nonzero_size = 0;
-#endif
-        }
-        // Only chunk datasets where we would have >1 chunk
-        int large_dataset = 0;
-        for(int i=0; i<rank; i++)
-        {
-#ifdef USEPARALLELHDF
-            if ((flag_parallel) & (opt.mpinprocswritesize>1)) {
-                if(mpi_hdf_dims_tot[i] > HDFOUTPUTCHUNKSIZE) large_dataset = 1;
-            }
-            else {
-                if(dims[i] > HDFOUTPUTCHUNKSIZE) large_dataset = 1;
-            }
-#else
-            if(dims[i] > HDFOUTPUTCHUNKSIZE) large_dataset = 1;
-#endif
-        }
-        if(nonzero_size && large_dataset)
-        {
-#ifdef USEPARALLELHDF
-            if ((flag_parallel) & (opt.mpinprocswritesize>1)) {
-                for(auto i=0; i<rank; i++) chunks[i] = min((hsize_t) HDFOUTPUTCHUNKSIZE, mpi_hdf_dims_tot[i]);
-            }
-            else {
-                for(auto i=0; i<rank; i++) chunks[i] = min((hsize_t) HDFOUTPUTCHUNKSIZE, dims[i]);
-            }
-#else
-            for(auto i=0; i<rank; i++) chunks[i] = min((hsize_t) HDFOUTPUTCHUNKSIZE, dims[i]);
-#endif
-        }
-
-        // Create the dataspace
-#ifdef USEPARALLELHDF
-        if ((flag_parallel) & (opt.mpinprocswritesize>1)) {
-            //then all threads create the same simple data space
-            //so the meta information is the same
-            if (flag_hyperslab) {
-                //allocate the space spanning the file
-                dspace_id = H5Screate_simple(rank, mpi_hdf_dims_tot.data(), NULL);
-                //allocate the memory space
-                //allocate the memory space
-                memspace_id = H5Screate_simple(rank, dims, NULL);
-            }
-            else {
-                dspace_id = H5Screate_simple(rank, dims, NULL);
-                memspace_id = dspace_id;
-            }
-        }
-        else {
-            dspace_id = H5Screate_simple(rank, dims, NULL);
-            memspace_id = dspace_id;
-        }
-#else
-        dspace_id = H5Screate_simple(rank, dims, NULL);
-        memspace_id = dspace_id;
-#endif
-
-        // Dataset creation properties
-        prop_id = H5P_DEFAULT;
-#ifdef USEHDFCOMPRESSOIN
-        // this defines compression
-        if(nonzero_size && large_dataset)
-        {
-            prop_id = H5Pcreate(H5P_DATASET_CREATE);
-            H5Pset_layout(prop_id, H5D_CHUNKED);
-            H5Pset_chunk(prop_id, rank, chunks.data());
-            H5Pset_deflate(prop_id, HDFDEFLATE);
-        }
-#endif
-        // Create the dataset
-        dset_id = H5Dcreate(file_id, name.c_str(), filetype_id, dspace_id,
-            H5P_DEFAULT, prop_id, H5P_DEFAULT);
-        if(dset_id < 0) io_error(string("Failed to create dataset: ")+name);
-        H5Pclose(prop_id);
-
-        prop_id = H5P_DEFAULT;
-#ifdef USEPARALLELHDF
-        if ((flag_parallel) & (opt.mpinprocswritesize>1)) {
-            // set up the collective transfer properties list
-            prop_id = H5Pcreate(H5P_DATASET_XFER);
-            //if all tasks are participating in the writes
-            if (flag_collective) ret = H5Pset_dxpl_mpio(prop_id, H5FD_MPIO_COLLECTIVE);
-            else ret = H5Pset_dxpl_mpio(prop_id, H5FD_MPIO_INDEPENDENT);
-            if (flag_hyperslab) {
-                H5Sselect_hyperslab(dspace_id, H5S_SELECT_SET, dims_offset.data(), NULL, dims, NULL);
-                if (dims[0] == 0) {
-                    H5Sselect_none(dspace_id);
-                    H5Sselect_none(memspace_id);
-                }
-
-            }
-            if (mpi_hdf_dims_tot[0] > 0) {
-                // Write the data
-                ret = H5Dwrite(dset_id, memtype_id, memspace_id, dspace_id, prop_id, data);
-                if (ret < 0) io_error(string("Failed to write dataset: ")+name);
-            }
-        }
-        else if (dims[0] > 0)
-        {
-            // Write the data
-            ret = H5Dwrite(dset_id, memtype_id, memspace_id, dspace_id, prop_id, data);
-            if (ret < 0) io_error(string("Failed to write dataset: ")+name);
-        }
-
-#else
-        // Write the data
-        if (dims[0] > 0) {
-            ret = H5Dwrite(dset_id, memtype_id, memspace_id, dspace_id, prop_id, data);
-            if (ret < 0) io_error(string("Failed to write dataset: ")+name);
-        }
-#endif
-
-        // Clean up (note that dtype_id is NOT a new object so don't need to close it)
-        H5Pclose(prop_id);
-#ifdef USEPARALLELHDF
-        if (flag_hyperslab && flag_parallel && (opt.mpinprocswritesize>1)) H5Sclose(memspace_id);
-#endif
-        H5Sclose(dspace_id);
-        H5Dclose(dset_id);
+      // Write the data
+      write_dataset_nd(opt, name, rank, dims, (void *) data,
+                       memtype_id, filetype_id,
+                       flag_parallel, flag_first_dim_parallel,
+                       flag_hyperslab, flag_collective);
     }
+
     void write_dataset_nd(Options opt, std::string name, int rank, hsize_t *dims, void *data,
         hid_t memtype_id = -1, hid_t filetype_id=-1,
         bool flag_parallel = true, bool flag_first_dim_parallel = true,

--- a/src/hdfitems.h
+++ b/src/hdfitems.h
@@ -753,8 +753,8 @@ class H5OutputFile
             for (auto i=0;i<rank;i++) {
                 dims_offset[i] = 0;
                 if (flag_first_dim_parallel && i > 0) continue;
-                for (auto j=1;j<=ThisWriteTask;j++) {
-                    dims_offset[i] += mpi_hdf_dims[i*NProcs+j-1];
+                for (auto j=0;j<ThisWriteTask;j++) {
+                    dims_offset[i] += mpi_hdf_dims[j*rank+i];
                 }
             }
             if (flag_first_dim_parallel && rank > 1) {


### PR DESCRIPTION
This addresses #24. When writing multidimensional output datasets in parallel mode the offsets into the dataset were calculated incorrectly.

There were multiple copies of the write_dataset_nd method in hdfitems.h, one templated and one taking a void * pointer for the input data. Rather than fix them both I've made the templated version just call the void * version with the data type parameter set. This is how it already works for 1D datasets.

Still needs testing.