### PR TITLE
Remove ftime usage

### DIFF
--- a/src/proto.h
+++ b/src/proto.h
@@ -839,10 +839,6 @@ void ReorderGroupIDsAndHaloDatabyValue(const Int_t numgroups, const Int_t newnum
 /// see \ref utilities.cxx for implementation
 //@{
 
-///Get current time in Milliseconds
-int GetMilliCount();
-///Get span in milliseconds
-int GetMillSpan(int );
 int CompareInt(const void *, const void *);
 ///Get memory use
 void GetMemUsage(Options &opt, string callingfunction, bool printreport);

--- a/src/utilities.cxx
+++ b/src/utilities.cxx
@@ -4,29 +4,6 @@
 
 #include "stf.h"
 
-/// Time functions
-//@{
-int GetMilliCount()
-{
-  // Something like GetTickCount but portable
-  // It rolls over every ~ 12.1 days (0x100000/24/60/60)
-  // Use GetMilliSpan to correct for rollover
-  timeb tb;
-  ftime( &tb );
-  int nCount = tb.millitm + (tb.time & 0xfffff) * 1000;
-  return nCount;
-}
-
-int GetMilliSpan( int nTimeStart )
-{
-  int nSpan = GetMilliCount() - nTimeStart;
-  if ( nSpan < 0 )
-    nSpan += 0x100000 * 1000;
-  return nSpan;
-}
-
-//@}
-
 int CompareInt(const void *p1, const void *p2) {
       Int_t val1 = *(Int_t*)p1;
       Int_t val2 = *(Int_t*)p2;


### PR DESCRIPTION
GetMilliSpan is not called by anyone (not even in TreeFrog), and
GetMilliCount was only called by GetMilliSpan. On top of this,
GetMilliCount used ftime() internally, which was removed in
POSIX.1-2008 (and therefore has been marked as deprecated in GNU libc).

This addresses #29.