### PR TITLE
Omp 5 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
      apt:
       sources: ubuntu-toolchain-r-test
       packages: [g++-5, libhdf5-dev, hdf5-tools, libgsl0-dev, libopenmpi-dev]
-    env: COMPILER=g++-5
+    env: COMPILER=g++-5 NOOMP=1
   - compiler: gcc
     addons:
      apt:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -35,6 +35,9 @@ mkdir build
 cd build
 
 VR_CMAKE_OPTIONS="-DCMAKE_CXX_COMPILER=$COMPILER -DCMAKE_BUILD_TYPE=Release"
+if [ "$NOOMP" = 1 ]; then
+	VR_CMAKE_OPTIONS+=" -DVR_OPENMP=OFF "
+fi
 if [ "$USEGAS" = 1 ]; then
 	VR_CMAKE_OPTIONS+=" -DVR_USE_GAS=ON "
 fi


### PR DESCRIPTION
A fix for a fix. OpenMP-disabled builds were accidentally broken after #25. Here were're adding OpenMP-disable builds and fixing the broken build.