### PR TITLE
Write metadata to all .profile files when using parallel HDF5

### DIFF
--- a/src/io.cxx
+++ b/src/io.cxx
@@ -2944,13 +2944,13 @@ void WriteProfiles(Options &opt, const Int_t ngroups, PropData *pdata){
     else if (opt.ibinaryout==OUTHDF) {
 #ifdef USEPARALLELHDF
         if(opt.mpinprocswritesize>1){
-            //if parallel then open file in serial so task 0 writes header
+            //if parallel then open file in serial so first task in each i/o communicator writes header
             Fhdf.create(string(fname),H5F_ACC_TRUNC, 0, false);
             MPI_Allreduce(&ng, &nwritecommtot, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, mpi_comm_write);
             MPI_Allreduce(&nhalos, &nhalowritecommtot, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, mpi_comm_write);
-            if (ThisTask == 0) {
+            if (ThisWriteTask == 0) {
                 itemp=0;
-                Fhdf.write_dataset(opt, datagroupnames.profile[itemp++], 1, &ThisWriteTask, -1, -1, false);
+                Fhdf.write_dataset(opt, datagroupnames.profile[itemp++], 1, &ThisWriteComm, -1, -1, false);
                 Fhdf.write_dataset(opt, datagroupnames.profile[itemp++], 1, &NWriteComms, -1, -1, false);
                 Fhdf.write_dataset(opt, datagroupnames.profile[itemp++], 1, &nwritecommtot, -1, -1, false);
                 Fhdf.write_dataset(opt, datagroupnames.profile[itemp++], 1, &ngtot, -1, -1, false);


### PR DESCRIPTION
When using parallel HDF5, Velociraptor writes multiple output files if MPI_number_of_tasks_per_write is less than the number of MPI ranks. This is implemented by making one communicator for each output file. All of the ranks in a communicator do a collective write to one output file. The files also contain some metadata which is written in serial mode by the first rank in the communicator.

If we have Calculate_radial_profiles=1 and are writing multiple files then the metadata is missing from all of the .profile files except the first one because only the first rank in MPI_COMM_WORLD writes the metadata. I think this is just a mistake because the other types of output (e.g. .properties) are not written like this.
 
This pull request changes the condition to write the metadata datasets so that they appear in all of the files. The file index written to the file was wrong too. It should be the index of the i/o communicator, not the rank with the communicator.