### PR TITLE
Enable CMP0074 policy when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,11 @@ set(CMAKE_CXX_STANDARD 11)
 # Set the code to always produce position independent code by default
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Let the *_ROOT variables indicate where to find packages (cmake >= 3.12)
+if (POLICY CMP0074)
+	cmake_policy(SET CMP0074 NEW)
+endif()
+
 #
 # Options users can give on the command line via -D
 #


### PR DESCRIPTION
Enabling this policy silences warnings seen in cosma (but likely to
happen in other places as well) when compiling VR with cmake >= 3.12,
and after loading modules that define <package>_ROOT environment
variables.

In particular, in cosma this was seen when find_package(MPI) ran because
there was an MPI_ROOT environment variable defined after loading the mpi
module in that system. This used to work (and continues to work) without
this policy because FindMPI looks for an MPI compiler in the PATH;
enabling the policy will not interfere with this, so there is no harm on
enabling it. Moreover, this might be helpful in other systems to find
not only MPI, but other packages.

This was highlighted by Stuart Mcalpine and John Helly during #33.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>