### PR TITLE
Prevent crash in AdjustStructureForPeriod when using one MPI rank

### DIFF
--- a/src/search.cxx
+++ b/src/search.cxx
@@ -2,6 +2,8 @@
  *  \brief this file contains routines that search particle list using FOF routines
  */
 
+#include <assert.h>
+
 //--  Suboutines that search particle list
 
 #include "stf.h"
@@ -457,6 +459,7 @@ Int_t* SearchFullSet(Options &opt, const Int_t nbodies, vector<Particle> &Part, 
             delete tree;
         }
         // Delete exported particles
+        assert(Part.size()==Nlocal);
         for (i = Nlocal-1; i >= 0; i--)
           if (Part[i].GetPotential() ==1.0) Part.pop_back();
           else break;

--- a/src/swiftinterface.cxx
+++ b/src/swiftinterface.cxx
@@ -472,8 +472,8 @@ vr_return_data InvokeVelociraptorHydro(const int snapnum, char* outputname,
     libvelociraptorOpt.cellnodeids = cell_node_ids;
 
     Nlocal=Nmemlocal=num_gravity_parts;
-    Nmemlocal*=(1+libvelociraptorOpt.mpipartfac); /* JSW: Not set in parameter file. */
 #ifdef USEMPI
+    if(NProcs>1)Nmemlocal*=(1+libvelociraptorOpt.mpipartfac); /* JSW: Not set in parameter file. */
     MPI_Allreduce(&Nlocal, &Ntotal, 1, MPI_Int_t, MPI_SUM, MPI_COMM_WORLD);
     MPI_Allgather(&Nlocal, 1, MPI_Int_t, mpi_nlocal, 1, MPI_Int_t, MPI_COMM_WORLD);
 #else


### PR DESCRIPTION
This addresses #34.