### PR TITLE
Fix macro name typo to enable HDF5 compression

### DIFF
--- a/src/hdfitems.h
+++ b/src/hdfitems.h
@@ -843,7 +843,7 @@ class H5OutputFile
 
         // Dataset creation properties
         prop_id = H5P_DEFAULT;
-#ifdef USEHDFCOMPRESSOIN
+#ifdef USEHDFCOMPRESSION
         // this defines compression
         if(nonzero_size && large_dataset)
         {


### PR DESCRIPTION
This was noted in #45. In the past the macro was defined (with the typo)
within the same file, but later on its definition was moved out to the
cmake infrastructure, where the correct spelling was used, hence the
incorrectly-spelled #ifdef block now always evaluate to false.

Since the names used to define and check the macro matched in the past,
I suspect the code within the #ifdef block was indeed exercised at some
point, and that it is correct (and at least it doesn't look obviously
incorrect). Hopefully this is still the case, and we won't be
introducing a new bug by allowing this code to compile.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>