### PR TITLE
Fix incorrect parsing logic

### DIFF
--- a/src/ui.cxx
+++ b/src/ui.cxx
@@ -808,7 +808,8 @@ void GetParamFile(Options &opt)
             getline(paramfile,line);
             //if line is not commented out or empty
             if (line[0]!='#'&&line.length()!=0) {
-                if (j=line.find(sep)){
+                j = line.find(sep);
+                if (j != std::string::npos) {
                     //clean up string
                     tag=line.substr(0,j);
                     strcpy(buff, tag.c_str());


### PR DESCRIPTION
This code, as previously written, entered into the "if" body even when
no separator ("=") was found. By good chance this didn't cause any
issues: because of how std::string::substr works the two calls issued
using the position value "j" ended up not throwing exceptions, although
both the parameter name and value would end up being equal to the full
line. This in turn means none of the subsequent "if" statements that set
different options are invoked.

Although this was probably never seen in the wild because configuration
files are seldom incorrectly written, a warning was generated by
different compilers (depending on version and warning flags). Since the
code is quite warning-full we never paid much attention to it until now.

The new code now properly checks that the result of the find call is
valid before using it.

This addresses #58.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>