### PR TITLE
Address two different memory leaks

### DIFF
--- a/src/search.cxx
+++ b/src/search.cxx
@@ -1398,8 +1398,10 @@ private(i,tid)
         numingroup=BuildNumInGroup(nsubset, numgroups, pfof);
         //pglist is constructed without assuming particles are in index order
         pglist=BuildPGList(nsubset, numgroups, numingroup, pfof, Partsubset);
+        // numgroups can change in CheckSignificance, which leads to a memleak
+        auto pglist_numgroups = numgroups;
         CheckSignificance(opt,nsubset,Partsubset,numgroups,numingroup,pfof,pglist);
-        for (i=1;i<=numgroups;i++) delete[] pglist[i];
+        for (i=1;i<=pglist_numgroups;i++) delete[] pglist[i];
         delete[] pglist;
         delete[] numingroup;
     }
@@ -2768,15 +2770,13 @@ inline void CleanAndUpdateGroupsFromSubSearch(Options &opt,
 
     if (opt.uinfo.unbindflag&&subngroup>0) {
         //if also keeping track of cores then must allocate coreflag
+        std::vector<Int_t> coreflag;
         if (numcores>0 && opt.iHaloCoreSearch>=1) {
-            coreflag=new Int_t[subngroup+1];
+            coreflag.resize(subngroup + 1);
             for (auto icore=1;icore<=subngroup;icore++) coreflag[icore]=1+(icore>subngroup-numcores);
         }
-        else {
-            coreflag=NULL;
-        }
         iunbindflag = CheckUnboundGroups(opt, subnumingroup, subPart,
-            subngroup, subpfof, subsubnumingroup, subsubpglist, 1, coreflag);
+            subngroup, subpfof, subsubnumingroup, subsubpglist, 1, coreflag.empty() ? nullptr : coreflag.data());
         if (iunbindflag) {
             for (auto j=1;j<=ng;j++) delete[] subsubpglist[j];
             delete[] subsubnumingroup;
@@ -2789,7 +2789,6 @@ inline void CleanAndUpdateGroupsFromSubSearch(Options &opt,
             if (numcores>0 && opt.iHaloCoreSearch>=1) {
                 numcores=0;
                 for (auto icore=1;icore<=subngroup;icore++) numcores += (coreflag[icore]==2);
-                delete[] coreflag;
             }
         }
     }


### PR DESCRIPTION
These are minor leaks, and probably don't accumulate greatly over time.
Anyways they should be addressed. Better solutions of course should be
sought with time, including more automatic memory management via vector,
unique_ptr and the like.

This fix addresses the problems highlighted in #60.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>