### PR TITLE
Patched RAMSES io for long IDs and int TYPE.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,9 @@ vr_option(GADGET_SPH_INFO   "Support for extra SPH information in Gadget" OFF)
 vr_option(GADGET_STAR_INFO  "Support for extra star information in Gadget" OFF)
 vr_option(GADGET_BH_INFO    "Support for extra black hole information in Gadget" OFF)
 
+# Ramses 
+vr_option(RAMSES_LONGIDS    "Support for long IDs in Ramses" OFF)
+
 # Particle data options
 vr_option(USE_STAR      "Use star particles" OFF)
 vr_option(USE_GAS       "Use gas particles" OFF)
@@ -165,6 +168,8 @@ vr_option_defines(GADGET_HEAD2              GADGET2FORMAT)
 vr_option_defines(GADGET_SPH_INFO           EXTRASPHINFO)
 vr_option_defines(GADGET_STAR_INFO          EXTRASTARINFO)
 vr_option_defines(GADGET_BH_INFO            EXTRABHINFO)
+
+vr_option_defines(RAMSES_LONGIDS            RAMSESLONGIDS)
 
 vr_option_defines(USE_GAS                   GASON)
 vr_option_defines(USE_STAR                  STARON)

--- a/src/ramsesitems.h
+++ b/src/ramsesitems.h
@@ -1,7 +1,7 @@
 /*! \file ramsesitems.h
  *  \brief this file contains definitions and routines for reading RAMSES files
- *  
- * RAMSES files come in 4 separate files, 
+ *
+ * RAMSES files come in 4 separate files,
  * amr_ file containing information about the cells (number, positions) etc
  * hydro_ file containing information about the hydrodynamical properties of the cells (density, velocity, pressure/gamma, then passive scalars like metallicity)
  * part_ file containing information about number of dark matter/star particles/sink (BH?) and their position/velocity info
@@ -17,11 +17,11 @@
 #define RAMSESFLOAT double
 #endif
 #ifdef RAMSESLONGIDS
-#define RAMSESIDTYPE int
+#define RAMSESIDTYPE long
 #else
 #define RAMSESIDTYPE  unsigned int
 #endif
-#define RAMSESINTTYPE int 
+#define RAMSESINTTYPE int
 
 ///number of particle types
 #define NRAMSESTYPE 5
@@ -37,7 +37,7 @@
 ///how many particle properties are read from file in one go
 #define RAMSESCHUNKSIZE 100000
 
-#define NUMRAMSESSPHBLOCKS 1 
+#define NUMRAMSESSPHBLOCKS 1
 
 ///\name Structures for the RAMSES interface
 //@{
@@ -61,10 +61,10 @@ struct RAMSES_Header {
     int         ngridmax;
     ///max number of boundary (ghost) cells in file (per domain?)
     int         nboundary;
-    ///number of active grids 
+    ///number of active grids
     int         ngridactive;
     //@}
-    ///\name hydro info 
+    ///\name hydro info
     //@{
     ///number of hydro variables
     int         nvarh;
@@ -94,6 +94,8 @@ struct RAMSES_Header {
 int RAMSES_fortran_read(fstream &, int &);
 int RAMSES_fortran_read(fstream &, RAMSESFLOAT &);
 int RAMSES_fortran_read(fstream &, int*);
+int RAMSES_fortran_read(fstream &, long*);
+int RAMSES_fortran_read(fstream &, long long*);
 int RAMSES_fortran_read(fstream &, RAMSESFLOAT *);
 int RAMSES_fortran_read(fstream &, RAMSESIDTYPE *);
 int RAMSES_fortran_skip(fstream &, int nskips=1);
@@ -103,4 +105,4 @@ int RAMSES_fortran_skip(fstream &, int nskips=1);
 Int_t RAMSES_get_nbodies(char *fname, int ptype, Options &opt);
 //@}
 
-#endif 
+#endif


### PR DESCRIPTION
Ramses particles IDs and Levels had the same type, although for some simulations IDs can be long and Levels int. This was causing an overflow of allocated memory. The bugfix takes care of this and adds the option to the CMakeLists to specify if IDs in the snapshot are long.