### PR TITLE
Give gas_sfr_threshold a default value of 0

### DIFF
--- a/src/allvars.h
+++ b/src/allvars.h
@@ -772,7 +772,7 @@ struct Options
     
     /// \name options related to calculating star forming gas quantities
     //@{
-    Double_t gas_sfr_threshold;
+    Double_t gas_sfr_threshold = 0;
     //@}
 
     /// \name options related to calculating detailed hydro/star/bh properties related to chemistry/feedbac, etc


### PR DESCRIPTION
This variable was not being initialised, and is never written to, and
thus code reading it cannot assume any consistent value, even between
two different runs.

This was reported in #79. Additionally we might want to add a new option
in the configuration file to allow users provide an arbitrary value for
this setting.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>