### PR TITLE
Remove unnecessary, problematic vector initialisation

### DIFF
--- a/src/substructureproperties.cxx
+++ b/src/substructureproperties.cxx
@@ -3564,10 +3564,6 @@ private(i,j,k,taggedparts,radii,masses,indices,posref,posparts,velparts,typepart
         pdata[i].M_200crit_interloper = 0;
         pdata[i].M_200mean_interloper = 0;
         pdata[i].M_BN98_interloper = 0;
-        for (auto iso=0;iso<opt.SOnum;iso++)
-        {
-            pdata[i].SO_mass_interloper[iso] = 0;
-        }
 #endif
 
         //calculate angular momentum if necessary


### PR DESCRIPTION
The SO_mass_interloper vector gets already filled with zeros when
resized, so there's no need to re-initialise it to zero again. Moreover,
this code didn't take into account the same condition used for resizing
the vector, and therefore it crashed when assigning values into an empty
vector.

This is the cause of the segmentation fault reported in #78.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>