### PR TITLE
Update to new versioned release of NBodylib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,7 +309,7 @@ endif()
 # We need to add it unless it was already added by somebody else
 if (NOT TARGET nbodylib)
 	add_subdirectory(NBodylib)
-	if (NBODYLIB_VERSION VERSION_LESS "1.28")
+	if (NBODYLIB_VERSION VERSION_LESS "1.29")
 		message(FATAL_ERROR "NBodyLib version ${NBODYLIB_VERSION} unsupported,
 		VELOCIraptor requires >= 1.28, try running git submodule update --recursive --remote")
 	endif()


### PR DESCRIPTION
We hadn't been increasing the version number in NBodylib, and therefore
made it a bit difficult for users to remember to update their
submodules.