### PR TITLE
Correctly calculate number of threads

### DIFF
--- a/src/unbind.cxx
+++ b/src/unbind.cxx
@@ -1147,7 +1147,7 @@ void PotentialTree(Options &opt, Int_t nbodies, Particle *&Part, KDTree* &tree)
     Int_t ntreecell, nleafcell;
     Double_t r2, eps2=opt.uinfo.eps*opt.uinfo.eps, mv2=opt.MassValue*opt.MassValue;
     int bsize = opt.uinfo.BucketSize;
-    int maxnthreads = 1, nthreads = 1;
+    int nthreads = 1;
     //for tree code potential calculation
     Int_t ncell;
     Int_t *start,*end;
@@ -1159,10 +1159,7 @@ void PotentialTree(Options &opt, Int_t nbodies, Particle *&Part, KDTree* &tree)
     bool runomp = false;
 #ifdef USEOPENMP
     runomp = (nbodies > POTOMPCALCNUM);
-    #pragma omp parallel
-        {
-        if (omp_get_thread_num()==0) maxnthreads=nthreads=omp_get_num_threads();
-        }
+    nthreads = omp_get_max_threads();
 #endif
 
     ncell=tree->GetNumNodes();


### PR DESCRIPTION
There were a couple of problems with the old version of this code.
Firstly, it had an unused maxthreads variable, which has now been
removed. Secondly, and more importantly, it used a complex and incorrect
way of calculating the number of threads (stored in the nthreads
variable) that would be used in new "omp parallel" blocks: instead of
directly calling omp_get_max_threads and writing its result into
nthreads (the new behavior) it opened an "omp parallel" block and called
omp_get_num_threads, only on the first thread of the newly created
thread team. The result was then written back to nthreads.

Although this seems fine, it creates a race condition, as there is no
guarantee that thread #0 in the newly formed team is the same thread
from which the team was created. This in turn means that the write to
nthreads is not necessarily visible immediately from the parent thread.
The nthreads value is later on used to allocate memory to be used by
"omp parallel" regions; having a wrong value (indeed the original 1 to
which nthreads is initialised to at declaration time) leads to
wrongly-sized memory blocks, and to invalid writes down the line.

We saw this problem when running with clang's address sanitizer, which
led us to find this particular bug in the code.

This problem was reported in #93.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>