### PR TITLE
Add the option to *not* consider the internal energy of the gas when performing the unbinding

### DIFF
--- a/src/allvars.h
+++ b/src/allvars.h
@@ -334,6 +334,8 @@ struct UnbindInfo
     //@}
     ///boolean as to whether code calculate potentials or potentials are externally provided
     bool icalculatepotential;
+    ///boolean to use (default) or not the internal energies when considering whether a gas element is bound.
+    bool iuseinternalenergy = true;
     ///fraction of potential energy that kinetic energy is allowed to be and consider particle bound
     Double_t Eratio;
     ///minimum bound mass fraction

--- a/src/ui.cxx
+++ b/src/ui.cxx
@@ -1007,6 +1007,8 @@ void GetParamFile(Options &opt)
                         opt.uinfo.unbindflag = atoi(vbuff);
                     else if (strcmp(tbuff, "Unbinding_type")==0)
                         opt.uinfo.unbindtype = atoi(vbuff);
+                    else if (strcmp(tbuff, "Unbinding_use_thermal_energy")==0)
+                        opt.uinfo.iuseinternalenergy = atoi(vbuff);
                     else if (strcmp(tbuff, "Bound_halos")==0)
                         opt.iBoundHalos = atoi(vbuff);
                     else if (strcmp(tbuff, "Allowed_kinetic_potential_ratio")==0)

--- a/src/unbind.cxx
+++ b/src/unbind.cxx
@@ -246,7 +246,8 @@ inline void GetBoundFractionAndMaxE(Options &opt,
         v2=0.0;for (auto k=0;k<3;k++) v2+=pow(groupPart[j].GetVelocity(k)-cmvel[k],2.0);
         Ti=0.5*mass*v2;
 #ifdef GASON
-        Ti+=mass*groupPart[j].GetU();
+	if(opt.uinfo.iuseinternalenergy)
+	  Ti+=mass*groupPart[j].GetU();
 #endif
         totT+=Ti;
         groupPart[j].SetDensity(opt.uinfo.Eratio*Ti+groupPart[j].GetPotential());


### PR DESCRIPTION
Does exactly what the title says :)

I think I set the default value correctly such that users who want the normal (old) behaviour are unaffected and can keep using their normal config files.

The rationale for this is that in the EAGLE family of model, we do heat particles to high temperatures when performing feedback but these particles are clearly not unbound.