### PR TITLE
Remove incorrect dataset name addition

### DIFF
--- a/src/hdfitems.h
+++ b/src/hdfitems.h
@@ -1135,7 +1135,6 @@ struct HDF_Part_Info {
 
             // Internal energies
             if(hdfnametype==HDFSWIFTEAGLENAMES) names[itemp++]=string("InternalEnergies");
-	    if(hdfnametype==HDFSWIFTFLAMINGONAMES) names[itemp++]=string("InternalEnergies");
             else names[itemp++]=string("InternalEnergy");
 
             // SFR


### PR DESCRIPTION
The recent changes introduced during #99 added the new "flamingo" HDF5
convention, which doesn't read the InternalEnergies field (see 1e00be9
and f95f406). However, the first versions of the patches added this
line, which not only adds "InternalEnergies" to the list of dataset
names to be read, but also adds it incorrectly: it uses a plain "if"
instead of an "else if", causing eagle HDF5 input files to be expected
to have both "InternalEnergies" and "InternalEnergy" fields.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>