### PR TITLE
Use correct types for sending vector sizes

### DIFF
--- a/src/mpiroutines.cxx
+++ b/src/mpiroutines.cxx
@@ -2684,12 +2684,12 @@ exchange_indices_and_props(
     assert(props.size() == indices.size() * props_per_index);
 
     // Send/recv number of indices to allocate reception buffers
-    int num_indices = indices.size();
-    int num_indices_recv;
+    unsigned long long num_indices = indices.size();
+    unsigned long long num_indices_recv;
     MPI_Status status;
     MPI_Sendrecv(
-        &num_indices, 1, MPI_Int_t, rank, tag * 2,
-        &num_indices_recv, 1, MPI_Int_t, rank, tag * 2,
+        &num_indices, 1, MPI_UNSIGNED_LONG_LONG, rank, tag * 2,
+        &num_indices_recv, 1, MPI_UNSIGNED_LONG_LONG, rank, tag * 2,
         mpi_comm, &status);
 
     // Send/recv actual indices and properties


### PR DESCRIPTION
The fix introduced in 1fa1e1e for #87 had itself a bug: we first stored
the size of the vector to be communicated as an int, and then declared
MPI we had an MPI_Int_t, which maps differently to MPI_LONG_LONG_INT or
MPI_INT depending on the LONGINT macro being defined or not. This
therefore doesn't work universally, leading to buffer overflows.

This commit declares the size variables as long long, and uses the
MPI_LONG_LONG_INT type explicitly during the MPI call. This makes the
communication safe regardless of the LONGINT macro being defined or not.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>