### PR TITLE
Warnings off

### DIFF
--- a/src/allvars.h
+++ b/src/allvars.h
@@ -2473,7 +2473,7 @@ struct PropData
 #endif
 #endif
 #ifdef STARON
-	M_star_incl*opt.h;
+        M_star_incl*=opt.h;
         M_star*=opt.h;
         M_star_rvmax*=opt.h;
         M_star_30kpc*=opt.h;

--- a/src/search.cxx
+++ b/src/search.cxx
@@ -1426,7 +1426,7 @@ private(i,tid)
         GridCell *grid;
         Double_t nf, ncl=opt.Ncell;
         //adjust ncellfac locally
-        nf=(opt.Ncellfac*8.0,MAXCELLFRACTION);
+        nf = std::min(opt.Ncellfac * Double_t{8}, Double_t{MAXCELLFRACTION});
         opt.Ncell=nf*nsubset;
 
         //ONLY calculate grid quantities if substructures have been found

--- a/src/stf-fitting.h
+++ b/src/stf-fitting.h
@@ -52,11 +52,18 @@ inline Double_t DiffSkewGaussSkew(Double_t x, void *param){
     else return 0.0;
 }
 
+static std::vector<double> to_vector(const gsl_vector *param, const gsl_fitting_data *fitdata)
+{
+    std::vector<double> params(fitdata->allparams, fitdata->allparams + fitdata->nallparams);
+    for (std::size_t i = 0; i < fitdata->npar; i++) {
+        params[fitdata->iparindex[i]] = gsl_vector_get(param, i);
+    }
+    return params;
+}
+
 inline int SkewGaussGSL(const gsl_vector *param, void *data, gsl_vector *f){
     gsl_fitting_data *fitdata = (gsl_fitting_data *)data;
-    vector<double> params(fitdata->nallparams);
-    for (int i=0;i<fitdata->nallparams;i++) params[i]=fitdata->allparams[i];
-    for (int i=0;i<fitdata->npar;i++) params[fitdata->iparindex[i]] = gsl_vector_get(param, i);
+    auto params = to_vector(param, fitdata);
     double x, y;
     for (int i=0; i<fitdata->n; i++) {
         x = fitdata ->x[i];
@@ -69,9 +76,7 @@ inline int SkewGaussGSL(const gsl_vector *param, void *data, gsl_vector *f){
 
 inline int DiffSkewGaussAmpGSL(const gsl_vector *param, void *data, gsl_vector *f){
     gsl_fitting_data *fitdata = (gsl_fitting_data *)data;
-    vector<double> params(fitdata->nallparams);
-    for (int i=0;i<fitdata->nallparams;i++) params[i]=fitdata->allparams[i];
-    for (int i=0;i<fitdata->npar;i++) params[fitdata->iparindex[i]] = gsl_vector_get(param, i);
+    auto params = to_vector(param, fitdata);
     double ivar=1.0/params[2];
     double is2=1.0/params[3];
     double x, y, dx2;
@@ -87,9 +92,7 @@ inline int DiffSkewGaussAmpGSL(const gsl_vector *param, void *data, gsl_vector *
 
 inline int DiffSkewGaussMeanGSL(const gsl_vector *param, void *data, gsl_vector *f){
     gsl_fitting_data *fitdata = (gsl_fitting_data *)data;
-    vector<double> params(fitdata->nallparams);
-    for (int i=0;i<fitdata->nallparams;i++) params[i]=fitdata->allparams[i];
-    for (int i=0;i<fitdata->npar;i++) params[fitdata->iparindex[i]] = gsl_vector_get(param, i);
+    auto params = to_vector(param, fitdata);
     double ivar=1.0/params[2];
     double is2=1.0/params[3];
     double x, y, dx2;
@@ -106,9 +109,7 @@ inline int DiffSkewGaussMeanGSL(const gsl_vector *param, void *data, gsl_vector 
 
 inline int DiffSkewGaussVarGSL(const gsl_vector *param, void *data, gsl_vector *f){
     gsl_fitting_data *fitdata = (gsl_fitting_data *)data;
-    vector<double> params(fitdata->nallparams);
-    for (int i=0;i<fitdata->nallparams;i++) params[i]=fitdata->allparams[i];
-    for (int i=0;i<fitdata->npar;i++) params[fitdata->iparindex[i]] = gsl_vector_get(param, i);
+    auto params = to_vector(param, fitdata);
     double ivar=1.0/params[2];
     double is2=1.0/params[3];
     double x, y, dx2;
@@ -124,9 +125,7 @@ inline int DiffSkewGaussVarGSL(const gsl_vector *param, void *data, gsl_vector *
 
 inline int DiffSkewGaussSkewGSL(const gsl_vector *param, void *data, gsl_vector *f){
     gsl_fitting_data *fitdata = (gsl_fitting_data *)data;
-    vector<double> params(fitdata->nallparams);
-    for (int i=0;i<fitdata->nallparams;i++) params[i]=fitdata->allparams[i];
-    for (int i=0;i<fitdata->npar;i++) params[fitdata->iparindex[i]] = gsl_vector_get(param, i);
+    auto params = to_vector(param, fitdata);
     double ivar=1.0/params[2];
     double is2=1.0/params[3];
     double x, y, dx2;

--- a/src/stf-fitting.h
+++ b/src/stf-fitting.h
@@ -65,7 +65,7 @@ inline int SkewGaussGSL(const gsl_vector *param, void *data, gsl_vector *f){
     gsl_fitting_data *fitdata = (gsl_fitting_data *)data;
     auto params = to_vector(param, fitdata);
     double x, y;
-    for (int i=0; i<fitdata->n; i++) {
+    for (std::size_t i = 0; i < fitdata->n; i++) {
         x = fitdata ->x[i];
         if (x<=params[1]) y = params[0]*exp(-0.5*(x-params[1])*(x-params[1])/(params[2]*params[3]));
         else y = params[0]*exp(-0.5*(x-params[1])*(x-params[1])/(params[2]));
@@ -80,7 +80,7 @@ inline int DiffSkewGaussAmpGSL(const gsl_vector *param, void *data, gsl_vector *
     double ivar=1.0/params[2];
     double is2=1.0/params[3];
     double x, y, dx2;
-    for (int i=0; i<fitdata->n; i++) {
+    for (std::size_t i = 0; i < fitdata->n; i++) {
         x = fitdata->x[i];
         dx2=(x-params[1])*(x-params[1]);
         if (x<=params[1]) y = exp(-0.5*dx2*ivar*is2);
@@ -96,7 +96,7 @@ inline int DiffSkewGaussMeanGSL(const gsl_vector *param, void *data, gsl_vector 
     double ivar=1.0/params[2];
     double is2=1.0/params[3];
     double x, y, dx2;
-    for (int i=0; i<fitdata->n; i++) {
+    for (std::size_t i = 0; i < fitdata->n; i++) {
         x = fitdata->x[i];
         dx2=(x-params[1])*(x-params[1]);
         if (x<params[1]) y = params[0]*exp(-0.5*dx2*ivar*is2)*(x-params[1])*ivar*is2;
@@ -113,7 +113,7 @@ inline int DiffSkewGaussVarGSL(const gsl_vector *param, void *data, gsl_vector *
     double ivar=1.0/params[2];
     double is2=1.0/params[3];
     double x, y, dx2;
-    for (int i=0; i<fitdata->n; i++) {
+    for (std::size_t i = 0; i < fitdata->n; i++) {
         x = fitdata->x[i];
         dx2=(x-params[1])*(x-params[1]);
         if (x<=params[1]) y = params[0]*exp(-0.5*dx2*ivar*is2)*dx2*ivar*ivar*is2*0.5;
@@ -129,7 +129,7 @@ inline int DiffSkewGaussSkewGSL(const gsl_vector *param, void *data, gsl_vector 
     double ivar=1.0/params[2];
     double is2=1.0/params[3];
     double x, y, dx2;
-    for (int i=0; i<fitdata->n; i++) {
+    for (std::size_t i = 0; i < fitdata->n; i++) {
         x = fitdata->x[i];
         dx2=(x-params[1])*(x-params[1]);
         if (x<=params[1]) y = params[0]*exp(-0.5*dx2*ivar*is2)*dx2*ivar*is2*is2*0.5;
@@ -142,7 +142,7 @@ inline int DiffSkewGaussSkewGSL(const gsl_vector *param, void *data, gsl_vector 
 inline int DiffSkewGaussGSL(const gsl_vector *param, void *data, gsl_matrix *J){
     gsl_fitting_data *fitdata = (gsl_fitting_data *)data;
     gsl_vector * f = gsl_vector_alloc(fitdata->n);
-    for (int iparam = 0; iparam < fitdata->npar; iparam++) {
+    for (std::size_t iparam = 0; iparam < fitdata->npar; iparam++) {
         int activeparam = fitdata->iparindex[iparam];
         switch(activeparam)
         {
@@ -159,7 +159,7 @@ inline int DiffSkewGaussGSL(const gsl_vector *param, void *data, gsl_matrix *J){
                 DiffSkewGaussSkewGSL(param, data, f);
                 break;
         }
-        for (int i=0;i<fitdata->n;i++) {
+        for (std::size_t i = 0; i < fitdata->n; i++) {
             gsl_matrix_set (J, i, iparam, gsl_vector_get(f,i));
         }
     }


### PR DESCRIPTION
A small collection of cleanups for warnings that have been appearing more and more when compiling with clang or newer gcc version. Many more warnings are available to be cleaned up when compiling with `-Wall`, but those are future work.