### PR TITLE
Avoid copying Coordinate argument

### DIFF
--- a/src/proto.h
+++ b/src/proto.h
@@ -271,8 +271,6 @@ inline Int_t MergeHaloGroups(Options &opt, Particle *Partsubset, Int_t numgroups
 
 ///used for tree potential calculation (which is only used for large groups)
 void GetNodeList(Node *np, Int_t &ncell, Node **nodelist, const Int_t bsize);
-///used for tree walk in potential calculation
-inline void MarkCell(Node *np, Int_t *marktreecell, Int_t *markleafcell, Int_t &ntreecell, Int_t &nleafcell, const Int_t bsize, Double_t *cR2max, Coordinate *cm, Double_t *cmtot, Coordinate xpos, Double_t eps2);
 
 ///Interface for unbinding proceedure
 int CheckUnboundGroups(Options opt, const Int_t nbodies, Particle *Part, Int_t &ngroup, Int_t *&pfof, Int_t *numingroup=NULL, Int_t **pglist=NULL,int ireorder=1, Int_t *groupflag=NULL);

--- a/src/unbind.cxx
+++ b/src/unbind.cxx
@@ -23,7 +23,7 @@ void GetNodeList(Node *np, Int_t &ncell, Node **nodelist, const Int_t bsize){
 }
 
 ///subroutine that marks a cell for a given particle in tree-walk
-inline void MarkCell(Node *np, Int_t *marktreecell, Int_t *markleafcell, Int_t &ntreecell, Int_t &nleafcell, Double_t *r2val, const Int_t bsize, Double_t *cR2max, Coordinate *cm, Double_t *cmtot, Coordinate xpos, Double_t eps2){
+inline void MarkCell(Node *np, Int_t *marktreecell, Int_t *markleafcell, Int_t &ntreecell, Int_t &nleafcell, Double_t *r2val, const Int_t bsize, Double_t *cR2max, Coordinate *cm, Double_t *cmtot, const Coordinate &xpos, Double_t eps2){
     Int_t nid=np->GetID();
     Double_t r2;
     r2=0;


### PR DESCRIPTION
The xpos argument in MarkCells doesn't need to be copied from the caller
site to the callee, a constant reference is enough.

Moreover, I found there was a misalignment in the signature of
MarkCells, with the declaration missing a Double *r2val argument. Since
the function is local to unbund.cxx I simply removed it from proto.h.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>