### PR TITLE
Add missing broadcast

### DIFF
--- a/src/hdfio.cxx
+++ b/src/hdfio.cxx
@@ -483,6 +483,7 @@ inline void MPIUpdateExtraFieldOutputNames(Options &opt)
     broadcast_from_rank0(opt.star_chemproduction_output_names_aperture, opt.star_chemproduction_names_aperture);
 #endif
 #ifdef BHON
+    broadcast_from_rank0(opt.bh_internalprop_output_names, opt.bh_internalprop_names);
     broadcast_from_rank0(opt.bh_chem_output_names, opt.bh_chem_names);
     broadcast_from_rank0(opt.bh_chemproduction_output_names, opt.bh_chemproduction_names);
     broadcast_from_rank0(opt.bh_internalprop_output_names_aperture, opt.bh_internalprop_names_aperture);


### PR DESCRIPTION
The broadcasting of the opt.bh_internalprop_output_names vector was
something that originally existed in the codebase, but was accidentally
removed in 4cdbd52 while fixing #100. This missing broadcast meant that
different ranks had different values in this vector, which ultimately
affects the HDF5 dataset count and names that are written by each rank.
When using parallel HDF5 writing this led to misaligned collective
calls, and therefore to the problems described in #102, which is the
issue this commit fixes.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>