### PR TITLE
Fix for issue 73

### DIFF
--- a/src/mpiroutines.cxx
+++ b/src/mpiroutines.cxx
@@ -3847,6 +3847,7 @@ Int_t MPIBuildParticleNNImportList(Options &opt, const Int_t nbodies, KDTree *tr
             if (taggedindex.size()==0) continue;
             for (auto &index:taggedindex) {
                 if (iflagged[index]) continue;
+                iflagged[index] = true;
 #ifdef STRUCDEN
                 if (iallflag==0 && Part[index].GetType()<0) continue;
 #endif
@@ -3854,7 +3855,6 @@ Int_t MPIBuildParticleNNImportList(Options &opt, const Int_t nbodies, KDTree *tr
                 nexport++;
                 nsend_local[j]++;
             }
-            for (auto &index:taggedindex) iflagged[index]=true;
         }
     }
     delete[] iflagged;


### PR DESCRIPTION
There was a delay between particles being visited, and being marked as
such (the loop for marking particles as visited came right after the
loop using particles). This worked well when individual calls to
SearchBallPos returned lists of indices without repetitions; if a list
of indices contains repetitions though (and the SearchBallPos algorithm
doesn't prevent this) then the nexport variable could be increased
beyond the extents of the PartDataIn allocation and cause problems,
which is exactly what happens in #73.

This commit moves the marking of visited particles to be within the same
loop where that particle is visited, right after the check.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>